### PR TITLE
Removed 'fixed' image dimensions.

### DIFF
--- a/private/www/netosuite/Templates/skeletal/thumbs/advert/banner.template.html
+++ b/private/www/netosuite/Templates/skeletal/thumbs/advert/banner.template.html
@@ -1,1 +1,1 @@
-<a href="[@url@]"><img src="[%asset_url type:'adw' id:'[@ad_id@]' default:'[@config:imageurl@]/pixel.gif'%][%END asset_url%]" width="[@img_width@]px" height="[@img_height@]px" alt="[@headline@]"></a>
+<a href="[@url@]"><img src="[%asset_url type:'adw' id:'[@ad_id@]' default:'[@config:imageurl@]/pixel.gif'%][%END asset_url%]" alt="[@headline@]"></a>


### PR DESCRIPTION
Gross on responsive. Is there a reason for these to be there? If user sets dimension in UI on upload, doesn't neto resize anyway?