### PR TITLE
truemaxlength to account for HTML encoding

### DIFF
--- a/private/www/netosuite/Templates/skeletal/thumbs/product/template.html
+++ b/private/www/netosuite/Templates/skeletal/thumbs/product/template.html
@@ -5,7 +5,7 @@
 			<img src="[%asset_url type:'product' thumb:'thumb' id:'[@SKU@]'%][%param default%][%cdn_asset html:'0' library:'images'%]default_product.gif[%/cdn_asset%][%end param%][%/asset_url%]" class="product-image" alt="[@model@]" rel="itmimg[@SKU@]">
 		</a>
 		<div class="caption">
-			<h3 itemprop="name"><a href="[@URL@]" title="[@model@]">[%format type:'text' maxlength:'50' rmhtml:'1'%][@model@][%/FORMAT%]</a></h3>
+			<h3 itemprop="name"><a href="[@URL@]" title="[@model@]">[%format type:'text' truemaxlength:'50' rmhtml:'1'%][@model@][%/FORMAT%]</a></h3>
 			<p class="price" itemprop="offers" itemscope itemtype="http://schema.org/Offer">
 				[%if [@inpromo@]%]
 					Now&nbsp;[%if [@has_child@]%]from&nbsp;[%/if%]


### PR DESCRIPTION
When using characters like '&' in the product name, when maxlength calculates, it calculates based on the encoded value for that character, cutting the resulting struct after 46 chars instead of 50