### PR TITLE
loading plugins against correct init code blocks

### DIFF
--- a/private/www/netosuite/Templates/skeletal/products/template.html
+++ b/private/www/netosuite/Templates/skeletal/products/template.html
@@ -18,13 +18,13 @@
 			[%/if%]
 		});
 	</script>
-	<script type="text/javascript" src="//cdn.neto.com.au/assets/neto-cdn/jcountdown/1.4/jquery.jcountdown.min.js"></script>
-		<script type="text/javascript">
+	<script type="text/javascript" src="//cdn.neto.com.au/assets/neto-cdn/zoom/1.4/jquery.zoom-min.js"></script>
+	<script type="text/javascript">
 		$(document).ready(function(){
 			$('.zoom').zoom();
 		});
 	</script>
-	<script type="text/javascript" src="//cdn.neto.com.au/assets/neto-cdn/zoom/1.4/jquery.zoom-min.js"></script>
+	<script type="text/javascript" src="//cdn.neto.com.au/assets/neto-cdn/jcountdown/1.4/jquery.jcountdown.min.js"></script>
 	<script type="text/javascript">
 		$(document).ready(function() {
 			$("#sale-end").countdown({


### PR DESCRIPTION
The zoom plugin and jcountdown had their respective plugin scripts being loaded against the wrong blocks of code, which is unnecessarily confusing