### PR TITLE
Adding structured data for promo_price to the product page header

### DIFF
--- a/src/templates/products/includes/header.template.html
+++ b/src/templates/products/includes/header.template.html
@@ -58,7 +58,7 @@
 						RRP [%FORMAT type:'currency'%][@retail@][%/FORMAT%]
 					</div>
 				[%/if%]
-				<div class="productpromo">
+				<div class="productpromo"  itemprop="price" content="[@promo_price@]">
 					NOW [%FORMAT type:'currency'%][@promo_price@][%/FORMAT%]
 				</div>
 				[%if [@save@] > 0%]


### PR DESCRIPTION
There was no structured data on the "Promotion" side of the promo conditional statement at all.