### PR TITLE
Removing target="[@target@]" from Advert URLs

### DIFF
--- a/src/templates/thumbs/advert/carousel.template.html
+++ b/src/templates/thumbs/advert/carousel.template.html
@@ -1,5 +1,5 @@
 <div id="[@count@]" class="item [%if [@count@] eq '0'%]active[%/if%]">
-	<a href="[@url@]" target="[@target@]">
+	<a href="[@url@]">
 		<img src="[%asset_url type:'adw' id:'[@ad_id@]'%][%param default%][%cdn_asset html:'0' library:'images'%]default_product.gif[%/cdn_asset%][%end param%][%/asset_url%]" class="home-banner-item" alt="[@headline@]" border="0" >
 		[%if [@headline@] or [@description@] or [@linktext@]%]
 			<div class="carousel-caption">

--- a/src/templates/thumbs/advert/scroll.template.html
+++ b/src/templates/thumbs/advert/scroll.template.html
@@ -1,5 +1,5 @@
 <div id="[@count@]" class="item [%DATA id:'count' if:'==' value:'0'%]active[%END DATA%]">
-	<a href="[@url@]" target="[@target@]">
+	<a href="[@url@]">
 		<img src="[%asset_url type:'adw' id:'[@ad_id@]'%][%param default%][%cdn_asset html:'0' library:'images'%]default_product.gif[%/cdn_asset%][%end param%][%END asset_url%]" width="[@img_width@]px" height="[@img_height@]px" alt="[@headline@]" border="0" >
 	</a>
 	<div class="carousel-caption">

--- a/src/templates/thumbs/advert/text.template.html
+++ b/src/templates/thumbs/advert/text.template.html
@@ -1,10 +1,10 @@
 <div class="col-md-6 col-lg-6">
 	<div class="thumbnail">
-		<a class="image pull-left" href="[@url@]" target="[@target@]"><img src="[%asset_url type:'adw' id:'[@ad_id@]'%][%param default%][%cdn_asset html:'0' library:'images'%]default_product.gif[%/cdn_asset%][%end param%][%END asset_url%]" width="100%" alt="[@headline@]" border="0" ></a>
+		<a class="image pull-left" href="[@url@]"><img src="[%asset_url type:'adw' id:'[@ad_id@]'%][%param default%][%cdn_asset html:'0' library:'images'%]default_product.gif[%/cdn_asset%][%end param%][%END asset_url%]" width="100%" alt="[@headline@]" border="0" ></a>
 		<div class="caption">
-			<h5 class="headline"><a href="[@url@]" target="[@target@]"><!--##[@headline@]##--></a></h5>
+			<h5 class="headline"><a href="[@url@]"><!--##[@headline@]##--></a></h5>
 			<p><!--##[%format type:'text' nohtml:'1' trim:'LE2R' wordlength:'27'%][@description@][%END format%]##--> <br/>
-			<a href="[@url@]" target="[@target@]"><!--##[@linktext@]##--></a></p>
+			<a href="[@url@]"><!--##[@linktext@]##--></a></p>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
The [@target@] tag doesn't have a database column to hold a value, nor any control panel UI to accept this value. It is always returning blank so we've redundantly got target="" on all advert templates that used this post-parsing. 