### PR TITLE
Refinements to how extra options work on the cart

### DIFF
--- a/src/templates/cart/shopping_cart.template.html
+++ b/src/templates/cart/shopping_cart.template.html
@@ -10,7 +10,7 @@
 			[%/if%]
 			<!-- Uncomment if you'd like a "Edit gift messages" button above the cart summary. Requires checkout_upsell_extra to be configured correctly.
 			[%if [@config:checkout_upsell_extra@]%]
-				<a class="btn btn-default" type="button" href="[%url page:'checkout' fn:'upsell'/%]" title="Create Quote From Cart"> <i class="fa fa-pencil icon-white"></i> Edit extra options</a>
+				<a class="btn btn-default" type="button" href="[%url page:'checkout' fn:'upsell'/%]" title="Edit extra options"> <i class="fa fa-pencil icon-white"></i> Edit extra options</a>
 			[%/if%] -->
 		</div>
 		<div class="col-xs-12 col-md-3">
@@ -47,7 +47,7 @@
 							<p class="small">
 								[@extra@]
 								[%if [@config:checkout_upsell_extra@]%]
-									<a class="btn btn-default btn-xs" type="button" href="[%url page:'checkout' fn:'upsell'/%]" title="Create Quote From Cart"> <i class="fa fa-pencil icon-white"></i></a>
+									<a class="btn btn-default btn-xs" type="button" href="[%url page:'checkout' fn:'upsell'/%]" title="Edit extra options"> <i class="fa fa-pencil icon-white"></i></a>
 								[%/if%]
 							</p>
 							[%if [@aff_id@] eq '[@config:AFF_EBAY_ID@]'%]

--- a/src/templates/cart/shopping_cart.template.html
+++ b/src/templates/cart/shopping_cart.template.html
@@ -4,12 +4,16 @@
 	</div>
 	[%load_template file:'cart/cart.error.html'/%]
 	<div class="row btn-stack">
-		[%config id:'ALLOW_USER_QUOTE' if:'==' value:'1'%]
-			<div class="col-xs-12 col-md-3">
-				<button class="btn btn-default btn-block" type="button" onclick="window.location='[%url page:'checkout' fn:'quote'/%]';" title="Create Quote From Cart"> <i class="fa fa-list-alt"></i> Create Quote From Cart </button>
-			</div>
-		[%/config%]
-		<div class="col-xs-12 col-md-3 [%config id:'ALLOW_USER_QUOTE' if:'==' value:'1'%]col-md-offset-6[%/config%][%config id:'ALLOW_USER_QUOTE' if:'==' value:'0'%]col-md-offset-9[%/config%]">
+		<div class="col-xs-12 col-md-9">
+			[%if [@config:allow_user_quote@] eq '1'%]
+				<button class="btn btn-default btn-block" type="button" onclick="window.location='[%url page:'checkout' fn:'quote'/%]';" title="Create Quote From Cart"> <i class="fa fa-list-alt"></i> Create Quote From Cart</button>
+			[%/if%]
+			<!-- Uncomment if you'd like a "Edit gift messages" button above the cart summary. Requires checkout_upsell_extra to be configured correctly.
+			[%if [@config:checkout_upsell_extra@]%]
+				<a class="btn btn-default" type="button" href="[%url page:'checkout' fn:'upsell'/%]" title="Create Quote From Cart"> <i class="fa fa-pencil icon-white"></i> Edit extra options</a>
+			[%/if%] -->
+		</div>
+		<div class="col-xs-12 col-md-3">
 			<button class="btn btn-success btn-lg btn-block" type="button" onclick="window.location='[%url page:'checkout' fn:'payment'/%]';" title="Checkout Now"><i class="fa fa-shopping-cart icon-white"></i> Checkout Now</button>
 		</div>
 	</div>
@@ -34,44 +38,44 @@
 						</tr>
 					</thead>
 					<tbody>
-
 					[%/param%]
 					[%param *body%]
-
 					<tr>
 						<td class="cartTable--column cartTable--column-image"><a href="[@url@]"><img class="img-responsive" src="[@thumb@]"/></a></td>
-						<td><a href="[@url@]">
-							<h4>[@model@] <i>[@extra@]</i></h4>
-							</a> [%if [@aff_id@] eq '[@config:AFF_EBAY_ID@]'%]
-							<p>eBay ID: [@aff_ref@]</p>
+						<td>
+							<a href="[@url@]"><h4>[@model@]</h4></a>
+							<p class="small">
+								[@extra@]
+								[%if [@config:checkout_upsell_extra@]%]
+									<a class="btn btn-default btn-xs" type="button" href="[%url page:'checkout' fn:'upsell'/%]" title="Create Quote From Cart"> <i class="fa fa-pencil icon-white"></i></a>
+								[%/if%]
+							</p>
+							[%if [@aff_id@] eq '[@config:AFF_EBAY_ID@]'%]
+								<p>eBay ID: [@aff_ref@]</p>
 							[%/if%]
-
 							[%if [@aff_id@] eq '[@config:AFF_FREE_ID@]'%]
-							<p><span class="label label-success">Free Gift</span></p>
+								<p><span class="label label-success">Free Gift</span></p>
 							[%/if%]
-
 							[%if [@preorder@]%]
-							<p><span class="label label-warning">On pre-order - Released [%format type:'date'%][@arrival_date@][%/format%]</span></p>
+								<p><span class="label label-warning">On pre-order - Released [%format type:'date'%][@arrival_date@][%/format%]</span></p>
 							[%/if%]
-
-
 							[%if [@has_components@]%]
-							[%cart_item_components counter:'[@counter@]'%]
-							[%param header%]
-							<ul class="list-unstyled">
-								[%/param%]
-								[%param *body%]
-								<li>
-									<input type="hidden" name="compsku[@count@]_[@component_count@]" value="[@SKU@]">
-									<label>[@model@] x </label>
-									<input type="text" min="[@min_assemble@]" max="[@max_assemble@]" name="compqty[@count@]_[@component_count@]" class="form-control [%if [@fixed_assemble@]%]readonly [%/if%]" [%if [@fixed_assemble@]%]readonly[%/if%] value="[@qty@]" size="3">
-								</li>
-								[%/param%]
-								[%param *footer%]
-							</ul>
-							<input type="hidden" name="components[@count@]" value="[@total_components@]">
-							[%/param%]
-							[%/cart_item_components%]
+								[%cart_item_components counter:'[@counter@]'%]
+									[%param header%]
+										<ul class="list-unstyled">
+									[%/param%]
+									[%param *body%]
+										<li>
+											<input type="hidden" name="compsku[@count@]_[@component_count@]" value="[@SKU@]">
+											<label>[@model@] x </label>
+											<input type="text" min="[@min_assemble@]" max="[@max_assemble@]" name="compqty[@count@]_[@component_count@]" class="form-control [%if [@fixed_assemble@]%]readonly [%/if%]" [%if [@fixed_assemble@]%]readonly[%/if%] value="[@qty@]" size="3">
+										</li>
+									[%/param%]
+									[%param *footer%]
+										</ul>
+										<input type="hidden" name="components[@count@]" value="[@total_components@]">
+									[%/param%]
+								[%/cart_item_components%]
 							[%/if%]
 							[%if [@gifts_available@]%]
 								<h4>Congratulations! The above purchase has made you eligible for [@gifts_available@] of the following FREE Gifts!</h4>
@@ -84,7 +88,7 @@
 									[%PARAM *body%]
 										<div class="col-md-4">
 											<div class="thumbnail">
-												<a href="[%url type:'item ' id:'[@SKU@]'%][%END url%]" class="thumbnail-image"><img width="120" height="120" src="[@thumb@]" alt="[@model@]" /> </a>
+												<a href="[%url type:'item ' id:'[@SKU@]'/%]" class="thumbnail-image"><img width="120" height="120" src="[@thumb@]" alt="[@model@]" /> </a>
 												<div class="caption"> <a href="[%url type:'item' id:'[@SKU@]'/%]">[%format type:'text' maxlength:'70' rmhtml:'1'%][@model@][%/format%]</a>
 													<p><a class="btn btn-success btn-block"href="[%url page:'checkout' qs:'sku=[@SKU@]&gift=[@counter@]'/%]">Add to Cart</a> </p>
 												</div>
@@ -119,9 +123,6 @@
 			</form>
 		</div>
 	</div>
-
-
-
 	<div class="row">
 		<div class="col-xs-12">
 			<hr>
@@ -312,7 +313,6 @@
 		</div>
 	</div>
 </div>
-
 <!-- Do not edit below this line-->
 <script type="text/javascript" language="javascript">
 function rmcart (id) { var obj = document.getElementById(id); if(obj) { obj.value="0"; document.checkout.submit(); } }


### PR DESCRIPTION
- If `CHECKOUT_UPSELL_EXTRA` is true, you can [edit the gift messages from the cart item](http://design.neto.com.au/assets/uploads/https___imaginenoatheme_neto_com_au__mycart_tkn_cart_ts_1469679694725839_1D49C21A.png). Just links to the upsell page, which already has the extra options there ready to be edited. Makes [this tweak](https://www.neto.com.au/designer-documentation/tweak-library/cart-page/edit-gift-message-button/) redundant.
- Extra options are on their own line, outside of the `<h4>` which the cart item name is inside.
- Cleaned up the logic around the **Create Quote From Cart** button.
- Added a top-level "Edit extra options" button, but it's commented out by default.

![](http://design.neto.com.au/assets/uploads/https___imaginenoatheme_neto_com_au__mycart_tkn_cart_ts_1469679694725839_1D49C21A.png)