### PR TITLE
Fixing readonly/value for fixed_assemble kits on the shopping cart

### DIFF
--- a/src/templates/cart/shopping_cart.template.html
+++ b/src/templates/cart/shopping_cart.template.html
@@ -68,7 +68,7 @@
 										<li>
 											<input type="hidden" name="compsku[@count@]_[@component_count@]" value="[@SKU@]">
 											<label>[@model@] x </label>
-											<input type="text" min="[@min_assemble@]" max="[@max_assemble@]" name="compqty[@count@]_[@component_count@]" class="form-control [%if [@fixed_assemble@]%]readonly [%/if%]" [%if [@fixed_assemble@]%]readonly[%/if%] value="[@qty@]" size="3">
+											<input type="text" min="[@min_assemble@]" max="[@max_assemble@]" name="compqty[@count@]_[@component_count@]" class="form-control [%if [@fixed_assemble@]%]readonly [%/if%]" [%if [@fixed_assemble@]%]readonly [%/if%] value="[@qty@]" size="3">
 										</li>
 									[%/param%]
 									[%param *footer%]


### PR DESCRIPTION
Due to the way b@se handles whitespace, the value & readonly attributes where being concatenated incorrectly