### PR TITLE
Adding a default spinner to .nactivity so it doesn't need to be added…

### DIFF
--- a/src/templates/footers/template.html
+++ b/src/templates/footers/template.html
@@ -187,6 +187,6 @@
 	<div class="npopup-body">
 	</div>
 </div>
-<div class="nactivity"></div>
+<div class="nactivity"><i class="fa fa-spinner fa-spin fa-inverse fa-3x fa-fw"></i></div>
 </body>
 </html>


### PR DESCRIPTION
… to be useful.

Show the loader:

```
$.nShowActivity('.nactivity');
```

Hide the loader:

```
$.nHideActivity();
```

Essentially dims the screen and shows the spinner.