### PR TITLE
Fix for variation-name width limitation

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -7126,9 +7126,6 @@ a.wishlist_toggle:hover {
   margin-bottom: 10px;
   display: block;
 }
-.variation-name {
-  width: 60px;
-}
 .buttontable a {
   font-size: 12px;
   height: 60px;

--- a/src/css/app.less
+++ b/src/css/app.less
@@ -450,10 +450,6 @@ a.wishlist_toggle:hover {
 	display:block;
 }
 
-.variation-name {
-	width:60px;
-}
-
 // Account Page
 .buttontable a {
 	font-size:12px;


### PR DESCRIPTION
There was width: 60px applying to the .variation-name class unnecessarily and causing word wrap for basically any two-word specific names. 