### PR TITLE
Fix Removing Freebies

### DIFF
--- a/src/templates/cart/shopping_cart.template.html
+++ b/src/templates/cart/shopping_cart.template.html
@@ -113,7 +113,18 @@
 							<h4>[%format type:'currency'%][@subtotal@][%/format%]</h4>
 						</td>
 						<td class="hidden-xs">
-							<a class="btn btn-block btn-danger" href="javascript:rmcart('qty[@count@]');"><i class="fa fa-trash-o"></i></a>
+							[%if [@aff_ref@] ne '' and [@aff_id@] eq 'free'%]
+								[%set [@rel_disc_code@]%][%split data1:[@aff_ref@] delimter:'*'%][%param *body%][%if [@count@] > 0%][@data1@][%/if%][%/param%][%/split%][%/set%]
+								[%active_coupons%]
+									[%param *body%]
+										[%if [@discount_id@] eq [@rel_disc_code@]%]
+											<a class="btn btn-block btn-danger" href="[%url page:'checkout' qs:'rmcpn=[@code@]'/%]"><i class="fa fa-trash-o"></i></a>
+										[%/if%]
+									[%/param%]
+								[%/active_coupons%]
+							[%else%]
+								<a class="btn btn-block btn-danger" href="javascript:rmcart('qty[@count@]');"><i class="fa fa-trash-o"></i></a>
+							[%/if%]
 						</td>
 					</tr>
 					[%/param%]


### PR DESCRIPTION
Removing freebie products the conventional way does not work, because they aren't normal products and can only be removed by removing the discount. The change proposed replaces the remove item button with a remove discount item if the product is detected as a freebie.

Note I did make some assumptions about what [@aff_ref@] and [@aff_id@] do.