### PR TITLE
Sales countdown for variation products

### DIFF
--- a/src/templates/products/template.html
+++ b/src/templates/products/template.html
@@ -10,6 +10,9 @@
 					'onReady' : function () {
 						$('.addtocart').button("reset");
 						$('.zoom').zoom();
+						$("#sale-end").countdown({
+							date: "[%format type:'date' format:'#K #d, #Y  #H:#I'%][@promo_end@][%/format%]"
+						});
 					},
 				}
 			});


### PR DESCRIPTION
Fix the sales countdown so that selecting variation products does not make the sales countdown vanish when the child product selected is still on sale.