### PR TITLE
Added no padding class for bootstrap columns

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -8202,3 +8202,7 @@ input[readonly] {
 .btn .fa {
   pointer-events: none;
 }
+.no-gutter > [class*='col-'] {
+  padding-right: 0;
+  padding-left: 0;
+}

--- a/src/css/app.less
+++ b/src/css/app.less
@@ -1342,3 +1342,8 @@ input[readonly] {background:#EFEFEF; color:666;}
 
 #_cpy_goback_pl {display:none;}
 .btn .fa {pointer-events:none;}
+
+.no-gutter > [class*='col-'] {
+    padding-right:0;
+    padding-left:0;
+}


### PR DESCRIPTION
Useful when styling columns in rows:

E.g:

```
<div class="row no-gutter">
    <div class="col-md-4">
        ...
    </div>
    <div class="col-md-4">
        ...
    </div>
    <div class="col-md-4">
        ...
    </div>
</div>
```