### PR TITLE
Change to parent products in editable kits to auto select a child

### DIFF
--- a/src/templates/products/includes/components.template.html
+++ b/src/templates/products/includes/components.template.html
@@ -68,11 +68,11 @@
 													[%/if%]
 												[%list_item_variations id:'[@current_sku@]'%]
 													[%PARAM *variation_header%]
+															<p>[@specific_name@]</p>
 															<select class="component-var-opt form-control component-config-input" component-id="[@component_count@]" ref="[@specific_id@]">
-																<option value="" disabled selected>[@specific_name@]</option>
 													[%/PARAM%]
 													[%PARAM *variation_body%]
-																<option value="[@value_id@]">[@value_name@] [%IF ![@variation_qty@]%](Out of Stock)[%/IF%]</option>
+																<option value="[@value_id@]" [%if [@selected@]%]selected[%/if%]>[@value_name@] [%IF ![@variation_qty@]%](Out of Stock)[%/IF%]</option>
 													[%/PARAM%]
 													[%PARAM *variation_footer%]
 																</select>


### PR DESCRIPTION
The old code can add the parent SKU to the cart. This change will auto select a child product so the correct SKU is added to the cart.

Note: There is a issue with the [@fixed_assemble@] tag as well. It is always set to one for parent products. Current work around is to add `[%set [@fixed_fixed_assemble@]%][%if [@min_assemble@] eq [@max_assemble@]%]1[%else%]0[%/if%][%/set%]` and replace `[@fixed_assemble@]` with `[@fixed_fixed_assemble@]` in the two references in the parent qty field.