### PR TITLE
Removed brands limit and show all link

### DIFF
--- a/src/templates/cms/includes/sidebar.template.html
+++ b/src/templates/cms/includes/sidebar.template.html
@@ -139,7 +139,7 @@
 							</li>
 						[%/PARAM%]
 					[%/PRODUCT_FILTER%]
-					[%PRODUCT_FILTER type:'brand' limit:'50' autohide:'0'%]
+					[%PRODUCT_FILTER type:'brand' autohide:'0'%]
 						[%PARAM header%]
 							<li class="list-group-item"><h4>Filter By Brand</h4></li>
 						[%/PARAM%]
@@ -155,9 +155,6 @@
 									</li>
 								[%/PARAM%]
 							[%/DATA%]
-						[%/PARAM%]
-						[%PARAM more%]
-							<li class="lv1"><a class="list-group-item" href="[%URL type:'page' id:'brands'%][%/URL%]">Show all brands...</a></li>
 						[%/PARAM%]
 					[%/PRODUCT_FILTER%]
 			</ul>


### PR DESCRIPTION
There is no default brands page, so the 'show all brands' link in the sidebar will link to nowhere. I've removed this link and the brands output limit.

Until we have a brands page as standard install we will create a tweak doc to add this functionality back in with a manually created brands page.