### PR TITLE
Fix Ajax Search Dropdown Item Selection

### DIFF
--- a/src/js/custom.js
+++ b/src/js/custom.js
@@ -28,7 +28,7 @@
 			// This renders the instant search results - edit design of ajax results here
 			$.initSearchField({
 				'result_header'		: '<ul class="nav nav-list">',
-				'result_body'		: '<li><a href="javascript:void(0);" search-keyword="##keyword##"><img border="0" src="##thumb##" width="36" height="36"/><span class="title">##model##</span></a></li>',
+				'result_body'		: '<li><a href="##url##" search-keyword="##keyword##"><img border="0" src="##thumb##" width="36" height="36"/><span class="title">##model##</span></a></li>',
 				'result_footer'		: '</ul>',
 				'category_header'	: '<ul class="nav nav-list">',
 				'category_body'		: '<li><a href="##url##"><span class="thumb"><img border="0" src="##thumb##" width="36" height="36"/></span><span class="title">##fullname##</span> <span class="label label-default">##typename##</span></a></li>',


### PR DESCRIPTION
Previously clicking an item in ajax search dropdown would make the system search for the name of the product clicked....not sure why it was setup this way but it means if the product name contains bad characters the customer is taken to a no results found search page. This instead takes the customer directly to the product page preventing the above from occurring and stopping customers from having to click twice.