### PR TITLE
Allow for full product name on thumbnail

### DIFF
--- a/src/templates/thumbs/product/template.html
+++ b/src/templates/thumbs/product/template.html
@@ -6,7 +6,7 @@
 			<img src="[%asset_url type:'product' thumb:'thumb' id:'[@SKU@]'%][%param default%][%cdn_asset html:'0' library:'images'%]default_product.gif[%/cdn_asset%][%end param%][%/asset_url%]" class="product-image" alt="[@model@]" rel="itmimg[@SKU@]">
 		</a>
 		<div class="caption">
-			<h3 itemprop="name"><a href="[@URL@]" title="[@model@]">[%format type:'text' truemaxlength:'50' rmhtml:'1'%][@model@][%/FORMAT%]</a></h3>
+			<h3 itemprop="name"><a href="[@URL@]" title="[@model@]">[%format type:'text' truemaxlength:'150' rmhtml:'1'%][@model@][%/FORMAT%]</a></h3>
 			<p class="price" itemprop="offers" itemscope itemtype="http://schema.org/Offer">
 				[%if [@inpromo@]%]
 					Now&nbsp;[%if [@has_child@]%]from&nbsp;[%/if%]


### PR DESCRIPTION
There isn't a reason not to have the full product name here when we have the following styling in app.css:

```
.thumbnail .caption h3 {
    height: 4em;
    overflow: hidden;
}
```

We might not get the whole 150 characters but having a limit of 50 will cut off the name when there technically is space. e.g A height of 4em can allow up to three lines of text - which can be more than 50 characters.