### PR TITLE
Purging Logos

### DIFF
--- a/src/templates/headers/template.html
+++ b/src/templates/headers/template.html
@@ -14,7 +14,7 @@
 [@config:GOOGLE_VERIFICATION_CODE@]
 <title>[%url_info name:'page_title'/%]</title>
 <link rel="canonical" href="[@config:canonical_url@]"/>
-<link rel="shortcut icon" href="/assets/favicon_logo.png"/>
+<link rel="shortcut icon" href="/assets/favicon_logo.png?[@config:neto_css_version@]"/>
 <link class="theme-selector" rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/app.css[%/ntheme_asset%]" media="all"/>
 <link rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/style.css[%/ntheme_asset%]" media="all"/>
 [%cdn_asset html:'1' type:'css' domain:'maxcdn.bootstrapcdn.com' library:'font-awesome' version:'4.4.0'%]css/font-awesome.min.css[%/cdn_asset%]
@@ -32,7 +32,7 @@
 	<div class="row row-padded">
 		<div class="col-xs-12 col-sm-4 wrapper-logo">
 			<a href="[@config:homeurl@]" title="[@config:company_name@]">
-				<img class="logo" src="[@config:imageurl@]/website_logo.png" alt="[@config:company_name@]"/>
+				<img class="logo" src="[@config:imageurl@]/website_logo.png?[@config:neto_css_version@]" alt="[@config:company_name@]"/>
 			</a>
 		</div>
 		<div class="col-xs-12 col-sm-4">


### PR DESCRIPTION
This change will cause logos to be purged when hitting save on the theme editor. Customers will be able to make sure all browsers see the new logo without needing a design tweak. Alternatively replace [@config:neto_css_version@] with a format function loading the date (only to the day) so that the logo is "purged" daily