### PR TITLE
Search Action Fix

### DIFF
--- a/src/templates/headers/template.html
+++ b/src/templates/headers/template.html
@@ -37,7 +37,7 @@
 		</div>
 		<div class="col-xs-12 col-sm-4">
 			<div class="header-search">
-				<form name="productsearch" method="get" action="/">
+				<form name="productsearch" method="get" action="[%URL type:'page' id:'home' nohost:'1'/%]">
 					<input type="hidden" name="rf" value="kw"/>
 					<div class="input-group">
 						<input class="form-control ajax_search" value="[%nohtml%][%filter ID:'keywords'%][%/filter%][%/nohtml%]" id="name_search" autocomplete="off" name="kw" type="text"/>


### PR DESCRIPTION
This will stop search breaking when users change the url for their home page. It will load the search url instead of trying to load `/` and redirecting the to homepage without the search terms in the url query string