### PR TITLE
Fixed sold out label

### DIFF
--- a/src/templates/products/includes/child_products.template.html
+++ b/src/templates/products/includes/child_products.template.html
@@ -48,7 +48,7 @@
 							<!--##[%ELSEIF [@store_quantity@] < 1 AND [@config:ALLOW_NOSTOCK_CHECKOUT@] %]##-->
 							<span class="label label-warning">Back Order</span>
 							<!--##[%ELSE%]##-->
-							<span class="label label-important">Sold Out</span>
+							<span class="label label-danger">Sold Out</span>
 							<!--##[%END IF%]##-->
 						</td>
 					</tr>


### PR DESCRIPTION
There is no label-important class, so the out of stock was displaying white text on a white background.