### PR TITLE
freebies shopping cart

### DIFF
--- a/src/templates/cart/shopping_cart.template.html
+++ b/src/templates/cart/shopping_cart.template.html
@@ -53,7 +53,7 @@
 							[%if [@aff_id@] eq '[@config:AFF_EBAY_ID@]'%]
 								<p>eBay ID: [@aff_ref@]</p>
 							[%/if%]
-							[%if [@aff_id@] eq '[@config:AFF_FREE_ID@]'%]
+							[%if [@aff_id@] eq "[@config:AFF_FREE_ID@]"%]
 								<p><span class="label label-success">Free Gift</span></p>
 							[%/if%]
 							[%if [@preorder@]%]
@@ -103,7 +103,7 @@
 						</td>
 						<td class="options-column">
 							<input name="line[@count@]" type="hidden" value="[@counter@]" />
-							<input id="qty[@count@]"  type="text" min="0" name="qty[@count@]" value="[@qty@]" class="form-control cart-qty" />
+							<input id="qty[@count@]"  type="text" min="0" name="qty[@count@]" value="[@qty@]" class="form-control cart-qty" [%if [@aff_id@] eq 'free'%] disabled [%/if%]/>
 						</td>
 						<td class="text-right">
 							[%if [@qty@] > 1%]<h5>[@qty@] x [%format type:'currency'%][@price@][%/format%]</h5>[%/if%]

--- a/src/templates/cart/shopping_cart.template.html
+++ b/src/templates/cart/shopping_cart.template.html
@@ -53,7 +53,7 @@
 							[%if [@aff_id@] eq '[@config:AFF_EBAY_ID@]'%]
 								<p>eBay ID: [@aff_ref@]</p>
 							[%/if%]
-							[%if [@aff_id@] eq "[@config:AFF_FREE_ID@]"%]
+							[%if [@aff_id@] eq '[@config:AFF_FREE_ID@]'%]
 								<p><span class="label label-success">Free Gift</span></p>
 							[%/if%]
 							[%if [@preorder@]%]


### PR DESCRIPTION
This is an extension to #218

Which was closed due to incorrect/unknown repository

## Remove freebie cart modifiers 

```
When a product is added to the cart as a freebie, remove the qty input and the remove from cart button since these do not function for freebie products.
```