### PR TITLE
AccountAddressChangeFix

### DIFF
--- a/src/js/custom.js
+++ b/src/js/custom.js
@@ -145,3 +145,21 @@ $('.nToggleMenu').click(function(){
 	var toggleTarget = $(this).attr('data-target')
 	$(toggleTarget).slideToggle();
 });
+
+// Account for timezone on local PC in time countdown
+// server_now should be a javascript date object representing the time on the server
+//    you can achieve this with new Date([%format type:'date' format:'#Y,#M-1,#D,#H,#I,#S,0'%]now[%/format%])
+// to_convert is another javascript date object and is the time you want converted to local time string for neto js countdown
+function convertToLocalCountdown(server_now, to_convert) {
+	var local_time = Math.floor(new Date().getTime());
+	var time_dif = Math.floor(server_now.getTime()) - local_time;
+	
+	var time_out = new Date(Math.floor(to_convert.getTime())+time_dif);
+	
+	var time_out_hours=(count_date.getHours() < 10) ? ("0" + count_date.getHours()) : count_date.getHours();
+	var time_out_mins=(count_date.getMinutes() < 10) ? ("0" + count_date.getMinutes()) : count_date.getMinutes();
+
+	var time_out_str = $.datepicker.formatDate("MM d, yy ",time_out)+count_hours+":"+count_mins;
+	
+	return time_out_str;
+}

--- a/src/templates/customer/edit_account/template.html
+++ b/src/templates/customer/edit_account/template.html
@@ -56,6 +56,15 @@ function checkPostCode(ta) {
 	}
 }
 
+function clearSubState(fid, oid) {
+	var f = document[fid];
+	var city = f[oid+'_city'];
+	var state = f[oid+'_state'];
+	
+	city.value="";
+	state.value="";
+}
+
 function getlocation(ta) {
 	var id ='';
 	var city_id = 'bill_city';
@@ -239,7 +248,7 @@ getlocation();
 				<div class="form-group">
 					<label for="bill_zip">Post Code </label>
 					<span class="small text-danger">Required</span>
-					<input class="form-control" type="text" name="bill_zip" id="bill_zip" value="[@bill_zip@]" size="50" maxlength="10" onChange="getlocation()" onKeyUp="getlocation()">
+					<input class="form-control" type="text" name="bill_zip" id="bill_zip" value="[@bill_zip@]" size="50" maxlength="10" onChange="clearSubState('UPDATEINFO','bill');getlocation()" onKeyUp="clearSubState('UPDATEINFO','bill');getlocation()">
 				</div>
 				<div class="form-group n-wrapper-form-control">
 					<label for="suburb_sl">Suburb Selector </label>

--- a/src/templates/customer/edit_address/template.html
+++ b/src/templates/customer/edit_address/template.html
@@ -108,7 +108,7 @@ ship-to addresses. You can then choose your appropriate address for each order y
 <div class="form-group">
 <label for="ship_zip">Zip Code / Postal Code</label>
 <span class="small text-danger">Required</span>
-<input class="form-control" type="text" name="ship_zip" id="ship_zip" value="[@ship_zip@]" size="50" maxlength="10" onChange="updloca('ship')" onKeyUp="updloca('ship')">
+<input class="form-control" type="text" name="ship_zip" id="ship_zip" value="[@ship_zip@]" size="50" maxlength="10" onChange="clearSubState('itemForm','ship');updloca('ship')" onKeyUp="clearSubState('itemForm','ship');updloca('ship')">
 </div>
 
 </div>
@@ -201,6 +201,15 @@ var httpReq ={};
 
 function onload(){
 	checkDeleteButton();
+}
+
+function clearSubState(fid, oid) {
+	var f = document[fid];
+	var city = f[oid+'_city'];
+	var state = f[oid+'_state'];
+	
+	city.value="";
+	state.value="";
 }
 
 function updloca(oid) {

--- a/src/templates/products/template.html
+++ b/src/templates/products/template.html
@@ -11,7 +11,7 @@
 						$('.addtocart').button("reset");
 						$('.zoom').zoom();
 						$("#sale-end").countdown({
-							date: "[%format type:'date' format:'#K #d, #Y  #H:#I'%][@promo_end@][%/format%]"
+							date: convertToLocalCountdown(new Date([%format type:'date' format:'#Y,#M-1,#D,#H,#I,#S,0'%]now[%/format%]), new Date([%format type:'date' format:'#Y,#M-1,#D,#H,#I,#S,0'%][@promo_end@][%/format%]))
 						});
 					},
 				}


### PR DESCRIPTION
If I change the postcode without selecting a suburb then the page will
let me submit the results and when I load this address on checkout it
lets me checkout with an invalid postcode/suburb/state combination. This
fix clears the suburb and state fields whenever the postcode field is
updated, forcing the customer to reselect a suburb and state before
updating the address