### PR TITLE
Consistency for default product image on product page vs thumbnails.

### DIFF
--- a/src/templates/products/includes/images.template.html
+++ b/src/templates/products/includes/images.template.html
@@ -1,10 +1,10 @@
 <meta property="og:image" content="[@full_image@]"/>
 
 <div class="main-image text-center">
-	<a href="[%asset_url type:'product' id:'[@SKU@]' thumb:'full' check_parent:'y'%][%END asset_url%]" class=" fancybox" rel="product_images">
+	<a href="[%asset_url type:'product' id:'[@SKU@]' thumb:'full' check_parent:'y'%][%param default%][%cdn_asset html:'0' library:'images'%]default_product.gif[%/cdn_asset%][%/param%][%END asset_url%]" class=" fancybox" rel="product_images">
 		<div class="zoom">
-			<img src="[%asset_url type:'product' id:'[@SKU@]' thumb:'full' check_parent:'y'%][%END asset_url%]" class="hidden" aria-hidden="true">
-			<img src="[%asset_url type:'product' id:'[@SKU@]' thumb:'thumbL' check_parent:'y'%][%END asset_url%]" rel="itmimg[@SKU@]" alt="[@name@]" border="0" id="main-image" itemprop="image">
+			<img src="[%asset_url type:'product' id:'[@SKU@]' thumb:'full' check_parent:'y'%][%param default%][%cdn_asset html:'0' library:'images'%]default_product.gif[%/cdn_asset%][%/param%][%END asset_url%]" class="hidden" aria-hidden="true">
+			<img src="[%asset_url type:'product' id:'[@SKU@]' thumb:'thumbL' check_parent:'y'%][%param default%][%cdn_asset html:'0' library:'images'%]default_product.gif[%/cdn_asset%][%/param%][%END asset_url%]" rel="itmimg[@SKU@]" alt="[@name@]" border="0" id="main-image" itemprop="image">
 		</div>
 	</a>
 </div>


### PR DESCRIPTION
Added CDN hosted `default_product.gif` as the default image on product page. This ensures a more consistent experience, showing the same default image that is shown on the thumbnail template. 