### PR TITLE
No page title attribute on cart and account page

### DIFF
--- a/src/templates/headers/template.html
+++ b/src/templates/headers/template.html
@@ -12,7 +12,7 @@
 <meta property="og:url" content="[@config:canonical_url@]"/>
 <meta property="og:description" content="[%url_info name:'meta_description'/%]"/>
 [@config:GOOGLE_VERIFICATION_CODE@]
-<title itemprop='name'>[%url_info name:'page_title'/%]</title>
+<title itemprop='name'>[%if [%url_info name:'page_title'/%] ne ''%][%url_info name:'page_title'/%][%else%][@CONFIG:WEBSITE_NAME@][%/if%]</title>
 <link rel="canonical" href="[@config:canonical_url@]" itemprop="url"/>
 <link rel="shortcut icon" href="/assets/favicon_logo.png?[@config:neto_css_version@]"/>
 <link class="theme-selector" rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/app.css[%/ntheme_asset%]" media="all"/>


### PR DESCRIPTION

## Problem
The tag `[%url_info name:'page_title'/%]` returns nothing when accessing the following URLs:
/_mycart
/_myacct

This leads to no title being displayed in the tab so the browser will just display the ugly full URL.

Refer to issue #276

## Solution
We should check if the url_info function returns a blank string, and if so, fall back to displaying the website name via `[@CONFIG:WEBSITE_NAME@]`. 

