### PR TITLE
Match Out Of Stock button styling with other buttons on list view thumbnails

### DIFF
--- a/src/templates/thumbs/product/list.template.html
+++ b/src/templates/thumbs/product/list.template.html
@@ -53,7 +53,7 @@
 					[%elseif [@store_quantity@] < 1 AND [@config:ALLOW_NOSTOCK_CHECKOUT@] %]
 						<button type="button" title="Add to Cart" class="addtocart btn-primary btn btn-loads" rel="[@rndm@][@sku@]" data-loading-text="<i class='fa fa-spinner fa-spin' style='font-size: 14px'></i>">Backorder</button>
 					[%else%]
-						<a class="notify_popup btn btn-default btn-block btn-loads" href="[@url@]" title="Notify Me When Back In Stock" data-loading-text="<i class='fa fa-spinner fa-spin' style='font-size: 14px'></i>">Out Of Stock</a>
+						<a class="notify_popup btn btn-default btn-loads" href="[@url@]" title="Notify Me When Back In Stock" data-loading-text="<i class='fa fa-spinner fa-spin' style='font-size: 14px'></i>">Out Of Stock</a>
 					[%/if%]
 				</form>
 			</div>


### PR DESCRIPTION
Removed `.btn-block` class from Out Of Stock button on list view thumbnail to match styling of other buttons.