### PR TITLE
Fix Tax Label on Shopping Cart

### DIFF
--- a/src/templates/cart/shopping_cart.template.html
+++ b/src/templates/cart/shopping_cart.template.html
@@ -247,7 +247,7 @@
 				[%/if%]
 				[%if ![@notax@]%]
 				<tr>
-					<td>GST [%if [@tax_inc@]%]Inc.[%/if%]</td>
+					<td>[@config:PRIMARY_TAX_LABEL@] [%if [@tax_inc@]%]Inc.[%/if%]</td>
 					<td class="text-right">[%format type:'currency'%][@tax_total@][%/format%]</td>
 				</tr>
 				[%/if%]


### PR DESCRIPTION
When the **Default tax code** is updated on the Currency & Tax Settings, the new tax label is not displayed on the Shopping Cart page