### PR TITLE
Updating 'category:' to 'filter_category:'

### DIFF
--- a/src/templates/cms/home.template.html
+++ b/src/templates/cms/home.template.html
@@ -41,7 +41,7 @@
 				</section>
 			[%/param%]
 			[%param *ifempty%]
-				[%random_products category:'0' template:'' limit:'8'%]
+				[%random_products filter_category:'' template:'' limit:'8'%]
 					[%param *header%]
 						<hr />
 						<section class="row" aria-label="Featured Products">


### PR DESCRIPTION
Update the opening line of the [%random_products %] tag to remove category:'0' and replace with filter_category:'' and reword the description surrounding the category parameter.

Current implementation does not display any random products when implemented on the home page.

Current code
[%random_products category:'0' template:'' limit:'8'%]

New Code
[%random_products filter_category:'' template:'' limit:'8' %]