### PR TITLE
Moved required code in header/footer into their own files

### DIFF
--- a/src/templates/footers/checkout.template.html
+++ b/src/templates/footers/checkout.template.html
@@ -102,18 +102,6 @@
 	</div>
 </div>
 <!-- Required Neto Scripts - DO NOT REMOVE -->
-[%cdn_asset html:'1' type:'js' library:'jquery' version:'1.11.3'%]jquery.min.js[%/cdn_asset%]
-[%cdn_asset html:'1' type:'js' library:'fancybox' version:'2.1.5'%]jquery.fancybox.pack.js[%/cdn_asset%]
-[%NETO_JS html:'1' id:'main' /%]
-[%cdn_asset html:'1' type:'js' library:'bootstrap' version:'3.2.0'%]bootstrap.min.js[%/cdn_asset%]
-<script type="text/javascript" src="[%ntheme_asset%]js/custom.js[%/ntheme_asset%]"></script>
-[%cdn_asset html:'1' type:'js' library:'jquery_ui' version:'1.11.1'%]js/jquery-ui-1.8.18.custom.min.js[%/cdn_asset%]
-[%SITE_VALUE id:'footer_javascript' type:'load'/%]
-<!-- Analytics -->
-[%tracking_code type:'Visitor' /%]
-<div class="npopup" style=""> <a href="javascript:void(0);" class="npopup-btn-close"></a>
-	<div class="npopup-body">
-	</div>
-</div>
+[%load_template file:'footers/includes/scripts.template.html'/%]
 </body>
 </html>

--- a/src/templates/footers/includes/scripts.template.html
+++ b/src/templates/footers/includes/scripts.template.html
@@ -1,0 +1,16 @@
+[%cdn_asset html:'1' type:'js' library:'jquery' version:'1.11.3'%]jquery.min.js[%/cdn_asset%]
+[%cdn_asset html:'1' type:'js' library:'fancybox' version:'2.1.5'%]jquery.fancybox.pack.js[%/cdn_asset%]
+[%NETO_JS html:'1' id:'main' /%]
+[%cdn_asset html:'1' type:'js' library:'bootstrap' version:'3.3.6'%]bootstrap.min.js[%/cdn_asset%]
+<script type="text/javascript" src="[%ntheme_asset%]js/custom.js[%/ntheme_asset%]"></script>
+[%cdn_asset html:'1' type:'js' library:'jquery_ui' version:'1.11.1'%]js/jquery-ui-1.8.18.custom.min.js[%/cdn_asset%]
+[%SITE_VALUE id:'footer_javascript' type:'load'/%]
+[%if [@form:disable_scripts@] ne 'true'%]
+<!-- Analytics -->
+[%tracking_code type:'Visitor' /%]
+[%/if%]
+<div class="npopup" style="" role="alertdialog" aria-atomic="true" aria-label="Popup" aria-describedby="npopupDesc" tabindex="-1">
+	<a href="javascript:void(0);" class="npopup-btn-close" aria-label="Close Popup"></a>
+	<div class="npopup-body" id="npopupDesc"></div>
+</div>
+<div class="nactivity"><i class="fa fa-spinner fa-spin fa-inverse fa-3x fa-fw"></i></div>

--- a/src/templates/footers/includes/scripts.template.html
+++ b/src/templates/footers/includes/scripts.template.html
@@ -10,7 +10,7 @@
 [%tracking_code type:'Visitor' /%]
 [%/if%]
 <div class="npopup" style="" role="alertdialog" aria-atomic="true" aria-label="Popup" aria-describedby="npopupDesc" tabindex="-1">
-	<a href="javascript:void(0);" class="npopup-btn-close" aria-label="Close Popup"></a>
+	<a href="javascript:void(0);" class="npopup-btn-close" role="button" aria-label="Close popup"></a>
 	<div class="npopup-body" id="npopupDesc"></div>
 </div>
 <div class="nactivity"><i class="fa fa-spinner fa-spin fa-inverse fa-3x fa-fw"></i></div>

--- a/src/templates/footers/template.html
+++ b/src/templates/footers/template.html
@@ -239,21 +239,6 @@
 	</div>
 </footer>
 <!-- Required Neto Scripts - DO NOT REMOVE -->
-[%cdn_asset html:'1' type:'js' library:'jquery' version:'1.11.3'%]jquery.min.js[%/cdn_asset%]
-[%cdn_asset html:'1' type:'js' library:'fancybox' version:'2.1.5'%]jquery.fancybox.pack.js[%/cdn_asset%]
-[%NETO_JS html:'1' id:'main' /%]
-[%cdn_asset html:'1' type:'js' library:'bootstrap' version:'3.3.6'%]bootstrap.min.js[%/cdn_asset%]
-<script type="text/javascript" src="[%ntheme_asset%]js/custom.js[%/ntheme_asset%]"></script>
-[%cdn_asset html:'1' type:'js' library:'jquery_ui' version:'1.11.1'%]js/jquery-ui-1.8.18.custom.min.js[%/cdn_asset%]
-[%SITE_VALUE id:'footer_javascript' type:'load'/%]
-[%if [@form:disable_scripts@] ne 'true'%]
-<!-- Analytics -->
-[%tracking_code type:'Visitor' /%]
-[%/if%]
-<div class="npopup" style="" role="alertdialog" aria-atomic="true" aria-label="Popup" aria-describedby="npopupDesc" tabindex="-1"> <a href="javascript:void(0);" class="npopup-btn-close" aria-label="Close Popup"></a>
-	<div class="npopup-body" id="npopupDesc">
-	</div>
-</div>
-<div class="nactivity"><i class="fa fa-spinner fa-spin fa-inverse fa-3x fa-fw"></i></div>
+[%load_template file:'footers/includes/scripts.template.html'/%]
 </body>
 </html>

--- a/src/templates/headers/checkout.template.html
+++ b/src/templates/headers/checkout.template.html
@@ -1,29 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-<meta name="keywords" content="[%url_info name:'meta_keywords'/%]"/>
-<meta name="description" content="[%url_info name:'meta_description'/%]"/>
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0"/>
-<meta property="og:image" content="[%if [@config:current_page_type@] eq 'product'%][@config:homeurl@][%asset_url type:'product' id:'[@SKU@]' thumb:'full'/%][%ELSEIF [@config:current_page_type@] eq 'content'%][@config:homeurl@][%ASSET_url type:'content' id:'[@content_id@]' default:'/assets/website_logo.png'%][%/ASSET_url%][%ELSE%][@config:homeurl@]/assets/website_logo.png[%/if%]"/>
-<meta property="og:title" content="[%url_info name:'page_title'/%]"/>
-<meta property="og:site_name" content="[@config:website_name@] "/>
-[@config:GOOGLE_VERIFICATION_CODE@]
-<title>[%url_info name:'page_title'/%]</title>
-<link rel="canonical" href="[@config:canonical_url@]"/>
-<link rel="shortcut icon" href="/assets/favicon_logo.png"/>
-<link class="theme-selector" rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/app.css[%/ntheme_asset%]" media="all"/>
-<link rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/style.css[%/ntheme_asset%]" media="all"/>
-[%cdn_asset html:'1' type:'css' domain:'maxcdn.bootstrapcdn.com' library:'font-awesome' version:'4.4.0'%]css/font-awesome.min.css[%/cdn_asset%]
-[%cdn_asset html:'1' type:'css' library:'jquery_ui' version:'1.11.1'%]css/custom-theme/jquery-ui-1.8.18.custom.css[%/cdn_asset%]
-[%cdn_asset html:'1' type:'css' library:'fancybox' version:'2.1.5'%]jquery.fancybox.css[%/cdn_asset%]
-<!--[if lte IE 8]>
-	[%cdn_asset html:'1' type:'js' library:'html5shiv' version:'3.7.0'%]html5shiv.js[%/cdn_asset%]
-	[%cdn_asset html:'1' type:'js' library:'respond.js' version:'1.3.0'%]respond.min.js[%/cdn_asset%]
-<![endif]-->
-[%if [@form:disable_scripts@] ne 'true'%]
-[%tracking_code type:'Declaration'/%]
-[%/if%]
+	[%load_template file:'headers/includes/head.template.html'/%]
+	<link class="theme-selector" rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/app.css[%/ntheme_asset%]" media="all"/>
+	<link rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/style.css[%/ntheme_asset%]" media="all"/>
 </head>
 <body id="n_[@config:current_page_type@]" class="n_[@CONFIG:TEMPLATELANG@]">
 <header class="container wrapper-header">

--- a/src/templates/headers/empty.template.html
+++ b/src/templates/headers/empty.template.html
@@ -1,32 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-<meta name="keywords" content="[%url_info name:'meta_keywords'/%]"/>
-<meta name="description" content="[%url_info name:'meta_description'/%]"/>
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0"/>
-<meta property="og:image" content="[%if [@config:current_page_type@] eq 'product'%][@config:homeurl@][%asset_url type:'product' id:'[@SKU@]' thumb:'full'/%][%ELSEIF [@config:current_page_type@] eq 'content'%][@config:homeurl@][%ASSET_url type:'content' id:'[@content_id@]' default:'/assets/website_logo.png'%][%/ASSET_url%][%ELSE%][@config:homeurl@]/assets/website_logo.png[%/if%]"/>
-<meta property="og:title" content="[%url_info name:'page_title'/%]"/>
-<meta property="og:site_name" content="[@config:website_name@]"/>
-<meta property="og:type" content="website"/>
-<meta property="og:url" content="[@config:canonical_url@]"/>
-<meta property="og:description" content="[%url_info name:'meta_description'/%]"/>
-[@config:GOOGLE_VERIFICATION_CODE@]
-<title>[%url_info name:'page_title'/%]</title>
-<link rel="canonical" href="[@config:canonical_url@]"/>
-<link rel="shortcut icon" href="/assets/favicon_logo.png"/>
-<link class="theme-selector" rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/app.css[%/ntheme_asset%]" media="all"/>
-<link rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/style.css[%/ntheme_asset%]" media="all"/>
-[%cdn_asset html:'1' type:'css' domain:'maxcdn.bootstrapcdn.com' library:'font-awesome' version:'4.4.0'%]css/font-awesome.min.css[%/cdn_asset%]
-[%cdn_asset html:'1' type:'css' library:'jquery_ui' version:'1.11.1'%]css/custom-theme/jquery-ui-1.8.18.custom.css[%/cdn_asset%]
-[%cdn_asset html:'1' type:'css' library:'fancybox' version:'2.1.5'%]jquery.fancybox.css[%/cdn_asset%]
-<!--[if lte IE 8]>
-	[%cdn_asset html:'1' type:'js' library:'html5shiv' version:'3.7.0'%]html5shiv.js[%/cdn_asset%]
-	[%cdn_asset html:'1' type:'js' library:'respond.js' version:'1.3.0'%]respond.min.js[%/cdn_asset%]
-<![endif]-->
-[%if [@form:disable_scripts@] ne 'true'%]
-[%tracking_code type:'Declaration'/%]
-[%/if%]
+	[%load_template file:'headers/includes/head.template.html'/%]
+	<link class="theme-selector" rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/app.css[%/ntheme_asset%]" media="all"/>
+	<link rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/style.css[%/ntheme_asset%]" media="all"/>
 </head>
 
 <body id="n_[@config:current_page_type@]" class="n_[@CONFIG:TEMPLATELANG@]">

--- a/src/templates/headers/includes/head.template.html
+++ b/src/templates/headers/includes/head.template.html
@@ -1,0 +1,26 @@
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<meta name="keywords" content="[%url_info name:'meta_keywords'/%]"/>
+<meta name="description" content="[%url_info name:'meta_description'/%]"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0"/>
+<meta property="og:image" content="[%if [@config:current_page_type@] eq 'product'%][@config:homeurl@][%asset_url type:'product' id:'[@SKU@]' thumb:'full'/%][%ELSEIF [@config:current_page_type@] eq 'content'%][@config:homeurl@][%ASSET_url type:'content' id:'[@content_id@]' default:'/assets/website_logo.png'%][%/ASSET_url%][%ELSE%][@config:homeurl@]/assets/website_logo.png[%/if%]"/>
+<meta property="og:title" content="[%url_info name:'page_title'/%]"/>
+<meta property="og:site_name" content="[@config:website_name@]"/>
+<meta property="og:type" content="website"/>
+<meta property="og:url" content="[@config:canonical_url@]"/>
+<meta property="og:description" content="[%url_info name:'meta_description'/%]"/>
+[@config:GOOGLE_VERIFICATION_CODE@]
+<title itemprop='name'>[%url_info name:'page_title'/%]</title>
+<link rel="canonical" href="[@config:canonical_url@]" itemprop="url"/>
+<link rel="shortcut icon" href="/assets/favicon_logo.png?[@config:neto_css_version@]"/>
+<link class="theme-selector" rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/app.css[%/ntheme_asset%]" media="all"/>
+<link rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/style.css[%/ntheme_asset%]" media="all"/>
+[%cdn_asset html:'1' type:'css' domain:'maxcdn.bootstrapcdn.com' library:'font-awesome' version:'4.7.0'%]css/font-awesome.min.css[%/cdn_asset%]
+[%cdn_asset html:'1' type:'css' library:'jquery_ui' version:'1.11.1'%]css/custom-theme/jquery-ui-1.8.18.custom.css[%/cdn_asset%]
+[%cdn_asset html:'1' type:'css' library:'fancybox' version:'2.1.5'%]jquery.fancybox.css[%/cdn_asset%]
+<!--[if lte IE 8]>
+	[%cdn_asset html:'1' type:'js' library:'html5shiv' version:'3.7.0'%]html5shiv.js[%/cdn_asset%]
+	[%cdn_asset html:'1' type:'js' library:'respond.js' version:'1.3.0'%]respond.min.js[%/cdn_asset%]
+<![endif]-->
+[%if [@form:disable_scripts@] ne 'true'%]
+	[%tracking_code type:'Declaration'/%]
+[%/if%]

--- a/src/templates/headers/includes/head.template.html
+++ b/src/templates/headers/includes/head.template.html
@@ -12,8 +12,6 @@
 <title itemprop='name'>[%url_info name:'page_title'/%]</title>
 <link rel="canonical" href="[@config:canonical_url@]" itemprop="url"/>
 <link rel="shortcut icon" href="/assets/favicon_logo.png?[@config:neto_css_version@]"/>
-<link class="theme-selector" rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/app.css[%/ntheme_asset%]" media="all"/>
-<link rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/style.css[%/ntheme_asset%]" media="all"/>
 [%cdn_asset html:'1' type:'css' domain:'maxcdn.bootstrapcdn.com' library:'font-awesome' version:'4.7.0'%]css/font-awesome.min.css[%/cdn_asset%]
 [%cdn_asset html:'1' type:'css' library:'jquery_ui' version:'1.11.1'%]css/custom-theme/jquery-ui-1.8.18.custom.css[%/cdn_asset%]
 [%cdn_asset html:'1' type:'css' library:'fancybox' version:'2.1.5'%]jquery.fancybox.css[%/cdn_asset%]

--- a/src/templates/headers/template.html
+++ b/src/templates/headers/template.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head itemscope itemtype="http://schema.org/WebSite">
 	[%load_template file:'headers/includes/head.template.html'/%]
+	<link class="theme-selector" rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/app.css[%/ntheme_asset%]" media="all"/>
+	<link rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/style.css[%/ntheme_asset%]" media="all"/>
 </head>
 <body id="n_[@config:current_page_type@]" class="n_[@CONFIG:TEMPLATELANG@]">
 <a href="#main-content" class="sr-only sr-only-focusable">Skip to main content</a>

--- a/src/templates/headers/template.html
+++ b/src/templates/headers/template.html
@@ -1,32 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head itemscope itemtype="http://schema.org/WebSite">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-<meta name="keywords" content="[%url_info name:'meta_keywords'/%]"/>
-<meta name="description" content="[%url_info name:'meta_description'/%]"/>
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0"/>
-<meta property="og:image" content="[%if [@config:current_page_type@] eq 'product'%][@config:homeurl@][%asset_url type:'product' id:'[@SKU@]' thumb:'full'/%][%ELSEIF [@config:current_page_type@] eq 'content'%][@config:homeurl@][%ASSET_url type:'content' id:'[@content_id@]' default:'/assets/website_logo.png'%][%/ASSET_url%][%ELSE%][@config:homeurl@]/assets/website_logo.png[%/if%]"/>
-<meta property="og:title" content="[%url_info name:'page_title'/%]"/>
-<meta property="og:site_name" content="[@config:website_name@]"/>
-<meta property="og:type" content="website"/>
-<meta property="og:url" content="[@config:canonical_url@]"/>
-<meta property="og:description" content="[%url_info name:'meta_description'/%]"/>
-[@config:GOOGLE_VERIFICATION_CODE@]
-<title itemprop='name'>[%url_info name:'page_title'/%]</title>
-<link rel="canonical" href="[@config:canonical_url@]" itemprop="url"/>
-<link rel="shortcut icon" href="/assets/favicon_logo.png?[@config:neto_css_version@]"/>
-<link class="theme-selector" rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/app.css[%/ntheme_asset%]" media="all"/>
-<link rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/style.css[%/ntheme_asset%]" media="all"/>
-[%cdn_asset html:'1' type:'css' domain:'maxcdn.bootstrapcdn.com' library:'font-awesome' version:'4.4.0'%]css/font-awesome.min.css[%/cdn_asset%]
-[%cdn_asset html:'1' type:'css' library:'jquery_ui' version:'1.11.1'%]css/custom-theme/jquery-ui-1.8.18.custom.css[%/cdn_asset%]
-[%cdn_asset html:'1' type:'css' library:'fancybox' version:'2.1.5'%]jquery.fancybox.css[%/cdn_asset%]
-<!--[if lte IE 8]>
-	[%cdn_asset html:'1' type:'js' library:'html5shiv' version:'3.7.0'%]html5shiv.js[%/cdn_asset%]
-	[%cdn_asset html:'1' type:'js' library:'respond.js' version:'1.3.0'%]respond.min.js[%/cdn_asset%]
-<![endif]-->
-[%if [@form:disable_scripts@] ne 'true'%]
-[%tracking_code type:'Declaration'/%]
-[%/if%]
+	[%load_template file:'headers/includes/head.template.html'/%]
 </head>
 <body id="n_[@config:current_page_type@]" class="n_[@CONFIG:TEMPLATELANG@]">
 <a href="#main-content" class="sr-only sr-only-focusable">Skip to main content</a>

--- a/src/templates/products/template.html
+++ b/src/templates/products/template.html
@@ -1,3 +1,56 @@
+[%site_value id:'footer_javascript'%]
+	<script type="text/javascript" language="javascript">
+		$(document).ready(function() {
+			$.product_variationInit({
+				'loadtmplates': ['_buying_options', '_images','_header'],
+				'fns' : {
+					'onLoad' : function () {
+						$('.addtocart').button("loading");
+						$('.variation-wrapper').addClass('disable-interactivity');
+					},
+					'onReady' : function () {
+						$('.addtocart').button("reset");
+						$('.zoom').zoom();
+						$('.variation-wrapper').removeClass('disable-interactivity');
+						$("#sale-end").countdown({
+							date: "[%format type:'date' format:'#K #d, #Y  #H:#I'%][@promo_end@][%/format%]"
+						});
+					},
+				}
+			});
+			[%if [@has_components@]%]
+				$.kit_variationInit({});
+			[%/if%]
+		});
+	</script>
+	<script type="text/javascript" src="//cdn.neto.com.au/assets/neto-cdn/zoom/1.4/jquery.zoom-min.js"></script>
+	<script type="text/javascript">
+		$(document).ready(function(){
+			$('.zoom').zoom();
+		});
+	</script>
+	<script type="text/javascript" src="//cdn.neto.com.au/assets/neto-cdn/jcountdown/1.4/jquery.jcountdown.min.js"></script>
+	<script type="text/javascript">
+		$(document).ready(function() {
+			$("#sale-end").countdown({
+				date: "[%format type:'date' format:'#K #d, #Y  #H:#I'%][@promo_end@][%/format%]"
+			});
+		});
+	</script>
+	<script>
+		$(document).ready(function(){
+			$("li[role='tab']").click(function(){
+				$("li[role='tab']").attr("aria-selected","false"); //deselect all the tabs
+			 	$(this).attr("aria-selected","true");  // select this tab
+				var tabpanid= $(this).attr("aria-controls"); //find out what tab panel this tab controls
+			   var tabpan = $("#"+tabpanid);
+				$("div[role='tabpanel']").attr("aria-hidden","true"); //hide all the panels
+				tabpan.attr("aria-hidden","false");  // show our panel
+			 });
+		})
+		$('#_jstl__buying_options').on('click', '.wishlist_toggle', function(e){e.preventDefault();})
+	</script>
+[%/site_value%]
 [%cache type:'display' id:'[@inventory_id@]'%]
 <div class="col-xs-12">
 	[%breadcrumb%]
@@ -462,43 +515,3 @@
 	</div><!--/.row-->
 </div><!--/.col-xs-12-->
 </div><!--/.row-->
-[%site_value id:'footer_javascript'%]
-	<script type="text/javascript" language="javascript">
-		$(document).ready(function() {
-			$.product_variationInit({
-				'loadtmplates': ['_buying_options', '_images','_header'],
-				'fns' : {
-					'onLoad' : function () {
-						$('.addtocart').button("loading");
-						$('.variation-wrapper').addClass('disable-interactivity');
-					},
-					'onReady' : function () {
-						$('.addtocart').button("reset");
-						$('.zoom').zoom();
-						$('.variation-wrapper').removeClass('disable-interactivity');
-						$("#sale-end").countdown({
-							date: "[%format type:'date' format:'#K #d, #Y  #H:#I'%][@promo_end@][%/format%]"
-						});
-					},
-				}
-			});
-			[%if [@has_components@]%]
-				$.kit_variationInit({});
-			[%/if%]
-		});
-	</script>
-	<script type="text/javascript" src="//cdn.neto.com.au/assets/neto-cdn/zoom/1.4/jquery.zoom-min.js"></script>
-	<script type="text/javascript">
-		$(document).ready(function(){
-			$('.zoom').zoom();
-		});
-	</script>
-	<script type="text/javascript" src="//cdn.neto.com.au/assets/neto-cdn/jcountdown/1.4/jquery.jcountdown.min.js"></script>
-	<script type="text/javascript">
-		$(document).ready(function() {
-			$("#sale-end").countdown({
-				date: "[%format type:'date' format:'#K #d, #Y  #H:#I'%][@promo_end@][%/format%]"
-			});
-		});
-	</script>
-[%/site_value%]

--- a/src/templates/products/template.html
+++ b/src/templates/products/template.html
@@ -1,43 +1,3 @@
-[%site_value id:'footer_javascript'%]
-	<script type="text/javascript" language="javascript">
-		$(document).ready(function() {
-			$.product_variationInit({
-				'loadtmplates': ['_buying_options', '_images','_header'],
-				'fns' : {
-					'onLoad' : function () {
-						$('.addtocart').button("loading");
-						$('.variation-wrapper').addClass('disable-interactivity');
-					},
-					'onReady' : function () {
-						$('.addtocart').button("reset");
-						$('.zoom').zoom();
-						$('.variation-wrapper').removeClass('disable-interactivity');
-						$("#sale-end").countdown({
-							date: "[%format type:'date' format:'#K #d, #Y  #H:#I'%][@promo_end@][%/format%]"
-						});
-					},
-				}
-			});
-			[%if [@has_components@]%]
-				$.kit_variationInit({});
-			[%/if%]
-		});
-	</script>
-	<script type="text/javascript" src="//cdn.neto.com.au/assets/neto-cdn/zoom/1.4/jquery.zoom-min.js"></script>
-	<script type="text/javascript">
-		$(document).ready(function(){
-			$('.zoom').zoom();
-		});
-	</script>
-	<script type="text/javascript" src="//cdn.neto.com.au/assets/neto-cdn/jcountdown/1.4/jquery.jcountdown.min.js"></script>
-	<script type="text/javascript">
-		$(document).ready(function() {
-			$("#sale-end").countdown({
-				date: "[%format type:'date' format:'#K #d, #Y  #H:#I'%][@promo_end@][%/format%]"
-			});
-		});
-	</script>
-[%/site_value%]
 [%cache type:'display' id:'[@inventory_id@]'%]
 <div class="col-xs-12">
 	[%breadcrumb%]
@@ -392,7 +352,7 @@
 								<div>
 									<strong>
 										[%if [@reviewname@]%]
-											By: <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">[@reviewname@]</span></span> on 
+											By: <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">[@reviewname@]</span></span> on
 										[%/if%]
 										<meta itemprop="datePublished" content="[%FORMAT type:'date'%][@insert_date@][%/FORMAT%]">[%FORMAT type:'date'%][@insert_date@][%/FORMAT%]
 									</strong>
@@ -502,3 +462,43 @@
 	</div><!--/.row-->
 </div><!--/.col-xs-12-->
 </div><!--/.row-->
+[%site_value id:'footer_javascript'%]
+	<script type="text/javascript" language="javascript">
+		$(document).ready(function() {
+			$.product_variationInit({
+				'loadtmplates': ['_buying_options', '_images','_header'],
+				'fns' : {
+					'onLoad' : function () {
+						$('.addtocart').button("loading");
+						$('.variation-wrapper').addClass('disable-interactivity');
+					},
+					'onReady' : function () {
+						$('.addtocart').button("reset");
+						$('.zoom').zoom();
+						$('.variation-wrapper').removeClass('disable-interactivity');
+						$("#sale-end").countdown({
+							date: "[%format type:'date' format:'#K #d, #Y  #H:#I'%][@promo_end@][%/format%]"
+						});
+					},
+				}
+			});
+			[%if [@has_components@]%]
+				$.kit_variationInit({});
+			[%/if%]
+		});
+	</script>
+	<script type="text/javascript" src="//cdn.neto.com.au/assets/neto-cdn/zoom/1.4/jquery.zoom-min.js"></script>
+	<script type="text/javascript">
+		$(document).ready(function(){
+			$('.zoom').zoom();
+		});
+	</script>
+	<script type="text/javascript" src="//cdn.neto.com.au/assets/neto-cdn/jcountdown/1.4/jquery.jcountdown.min.js"></script>
+	<script type="text/javascript">
+		$(document).ready(function() {
+			$("#sale-end").countdown({
+				date: "[%format type:'date' format:'#K #d, #Y  #H:#I'%][@promo_end@][%/format%]"
+			});
+		});
+	</script>
+[%/site_value%]


### PR DESCRIPTION
First-time Neto theme developers can be intimidated with the amount of necessary/required code in some templates and it can be very easy to accidentally remove some of this code and break the whole site.

It would be a good idea to place this code in an includes template so it is still apart of the template but developers do not have to worry about it. 


With theme depending off Skeletal, a benefit to this would be when a theme is built, it would pull the latest includes from skeletal so your theme would have the most up to date meta tags or maybe a script tag version if it ever gets updated in skeletal.

---

## Changes

headers/includes/head - has all the head HTML
footers/includes/script - has all Neto necessary scripts, site_value, tracking_code, npopup, nactivity.
product/template.html - Moved site_value to bottom of the template.

### Discussion

- Should these header/footer new includes be in one includes directory or how it has been done in this PR, each directory has its own includes subdirectory?
- Are head/script correct names for templates?
- Should the site_value on the products template be moved at all, or even should it be added to its own includes template?

