### PR TITLE
Child price in table view should use [@store_price@] tag

### DIFF
--- a/src/templates/products/includes/child_products.template.html
+++ b/src/templates/products/includes/child_products.template.html
@@ -38,7 +38,7 @@
 							<!--##[%END IF%]##-->
 						</td>
 						<td>
-							<div class="child-price"><!--##[%format type:'currency'%]##-->[@price@]<!--##[%END format%]##--></div>
+							<div class="child-price"><!--##[%format type:'currency'%]##-->[@store_price@]<!--##[%END format%]##--></div>
 							<!--##[%IF [@extra@] or [@has_child@] %]##-->
 							<a href="[@URL@]" title="Buying Options" class="btn btn-primary">See Buying Options</a>
 							<!--##[%ELSEIF [@store_quantity@] > 0 AND [@preorder@] %]##-->


### PR DESCRIPTION
For consistency with the other template files, the `child_products.template.html` file should also use the `[@store_price@]` instead of `[@price@]`. 

Using the `[@price@]` tag will also show the lowest multi level price, which isn't shown anywhere else in the system by default. This leads to confusion when the customer adds a child product to their cart and is charged a different (most likely higher) price. 