### PR TITLE
Fix styling of custom fields on register/wholesaleregister

### DIFF
--- a/src/templates/customer/login.template.html
+++ b/src/templates/customer/login.template.html
@@ -95,7 +95,7 @@
 							<div class="form-group">
 								<label for="[@field_id@]">[@field_name@]</label>
 								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+								<textarea class="form-control" rows="3" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]></textarea>
 							</div>
 						</div>
 						[%END PARAM%]

--- a/src/templates/customer/login.template.html
+++ b/src/templates/customer/login.template.html
@@ -95,7 +95,7 @@
 							<div class="form-group">
 								<label for="[@field_id@]">[@field_name@]</label>
 								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<textarea class="form-control" rows="3" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]></textarea>
+								<textarea class="form-control" style="resize:vertical;" rows="3" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]></textarea>
 							</div>
 						</div>
 						[%END PARAM%]

--- a/src/templates/customer/login.template.html
+++ b/src/templates/customer/login.template.html
@@ -79,83 +79,80 @@
 						</div>
 
 						[%EXTRA_CUSTOMER_FIELDS%]
-					[%PARAM *header%]
-						[%END PARAM%]
-					[%PARAM *integer_option%]
-						<div class="col-xs-12 col-md-6">
-							<div class="form-group">
-								<label for="[@field_id@]">[@field_name@]</label>
-								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
-							</div>
-						</div>
-						[%END PARAM%]
-					[%PARAM *text_option%]
-						[%site_value id:'register_textareas'%]
-							<div class="col-xs-12 col-md-12">
-								<div class="form-group">
-									<label for="[@field_id@]">[@field_name@]</label>
-									[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-									<textarea class="form-control" style="resize:vertical;" rows="3" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]></textarea>
+							[%PARAM *integer_option%]
+								<div class="col-xs-12 col-md-6">
+									<div class="form-group">
+										<label for="[@field_id@]">[@field_name@]</label>
+										[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
+										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+									</div>
 								</div>
-							</div>
-						[%/site_value%]
-						[%END PARAM%]
-					[%PARAM *short_text_option%]
-						<div class="col-xs-12 col-md-6">
-							<div class="form-group">
-								<label for="[@field_id@]">[@field_name@]</label>
-								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
-							</div>
-						</div>
-						[%END PARAM%]
-					[%PARAM *descimal_option%]
-						<div class="col-xs-12 col-md-6">
-							<div class="form-group">
-								<label for="[@field_id@]">[@field_name@]</label>
-								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
-							</div>
-						</div>
-						[%END PARAM%]
-					[%PARAM *boolean_option%]
-						[%site_value id:'register_checkboxes'%]
-							<div class="checkbox">
-								<label>
-									<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
-									[@field_name@]
-								</label>
-								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-							</div>
-						[%/site_value%]
-						[%END PARAM%]
-					[%PARAM *date_option%]
-						<div class="col-xs-12 col-md-6">
-							<div class="form-group">
-								<label for="[@field_id@]">[@field_name@]</label>
-								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<input class="form-control datepicker" id="[@field_id@]" name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
-							</div>
-						</div>
-						[%END PARAM%]
-					[%PARAM *selection_header%]
-						<div class="col-xs-12 col-md-6">
-							<div class="form-group">
-								<label for="[@field_id@]">[@field_name@]</label>
-								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<select id="[@field_id@]" name="[@field_id@]" class="form-control" [%if [@required_field@]%]required="true"[%/if%]>
-
-									[%END PARAM%]
-			[%PARAM *selection_body%]
-									<option value="[@option_value@]">[@option_value@]</option>
-									[%END PARAM%]
-			[%PARAM *selection_footer%]
-								</select>
-							</div>
-						</div>
-						[%END PARAM%]
-					[%END EXTRA_CUSTOMER_FIELDS%]
+							[%/PARAM%]
+							[%PARAM *text_option%]
+								[%site_value id:'register_textareas'%]
+									<div class="col-xs-12 col-md-12">
+										<div class="form-group">
+											<label for="[@field_id@]">[@field_name@]</label>
+											[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
+											<textarea class="form-control" style="resize:vertical;" rows="3" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]></textarea>
+										</div>
+									</div>
+								[%/site_value%]
+							[%/PARAM%]
+							[%PARAM *short_text_option%]
+								<div class="col-xs-12 col-md-6">
+									<div class="form-group">
+										<label for="[@field_id@]">[@field_name@]</label>
+										[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
+										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+									</div>
+								</div>
+							[%/PARAM%]
+							[%PARAM *descimal_option%]
+								<div class="col-xs-12 col-md-6">
+									<div class="form-group">
+										<label for="[@field_id@]">[@field_name@]</label>
+										[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
+										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+									</div>
+								</div>
+							[%/PARAM%]
+							[%PARAM *boolean_option%]
+								[%site_value id:'register_checkboxes'%]
+									<div class="checkbox">
+										<label>
+											<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
+											[@field_name@]
+										</label>
+										[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
+									</div>
+								[%/site_value%]
+							[%/PARAM%]
+							[%PARAM *date_option%]
+								<div class="col-xs-12 col-md-6">
+									<div class="form-group">
+										<label for="[@field_id@]">[@field_name@]</label>
+										[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
+										<input class="form-control datepicker" id="[@field_id@]" name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+									</div>
+								</div>
+							[%/PARAM%]
+							[%PARAM *selection_header%]
+								<div class="col-xs-12 col-md-6">
+									<div class="form-group">
+										<label for="[@field_id@]">[@field_name@]</label>
+										[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
+										<select id="[@field_id@]" name="[@field_id@]" class="form-control" [%if [@required_field@]%]required="true"[%/if%]>
+							[%/PARAM%]
+							[%PARAM *selection_body%]
+											<option value="[@option_value@]">[@option_value@]</option>
+							[%/PARAM%]
+							[%PARAM *selection_footer%]
+										</select>
+									</div>
+								</div>
+							[%/PARAM%]
+						[%/EXTRA_CUSTOMER_FIELDS%]
 						[%site_value id:'register_textareas' type:'load'/%]
 						<div class="clear"></div>
 						<div class="col-xs-12 col-md-12">

--- a/src/templates/customer/login.template.html
+++ b/src/templates/customer/login.template.html
@@ -118,13 +118,15 @@
 						</div>
 						[%END PARAM%]
 					[%PARAM *boolean_option%]
-						<div class="col-xs-12 col-md-6">
-							<div class="form-group">
-								<label for="[@field_id@]">[@field_name@]</label>
+						[%site_value id:'register_checkboxes'%]
+							<div class="checkbox">
+								<label>
+									<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
+									[@field_name@]
+								</label>
 								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<input type="checkbox" class="form-control" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
 							</div>
-						</div>
+						[%/site_value%]
 						[%END PARAM%]
 					[%PARAM *date_option%]
 						<div class="col-xs-12 col-md-6">
@@ -155,6 +157,7 @@
 						<div class="clear"></div>
 						<div class="col-xs-12 col-md-12">
 							<div class="form-group">
+								[%site_value id:'register_checkboxes' type:'load'/%]
 								<div class="checkbox">
 									<label>
 										<input name="regoptin" type="checkbox" value="Y" checked="checked" data-message="You can unsubscribe at any time."/>

--- a/src/templates/customer/login.template.html
+++ b/src/templates/customer/login.template.html
@@ -91,7 +91,7 @@
 						</div>
 						[%END PARAM%]
 					[%PARAM *text_option%]
-						<div class="col-xs-12 col-md-6">
+						<div class="col-xs-12 col-md-12">
 							<div class="form-group">
 								<label for="[@field_id@]">[@field_name@]</label>
 								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]

--- a/src/templates/customer/login.template.html
+++ b/src/templates/customer/login.template.html
@@ -91,13 +91,15 @@
 						</div>
 						[%END PARAM%]
 					[%PARAM *text_option%]
-						<div class="col-xs-12 col-md-12">
-							<div class="form-group">
-								<label for="[@field_id@]">[@field_name@]</label>
-								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<textarea class="form-control" style="resize:vertical;" rows="3" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]></textarea>
+						[%site_value id:'register_textareas'%]
+							<div class="col-xs-12 col-md-12">
+								<div class="form-group">
+									<label for="[@field_id@]">[@field_name@]</label>
+									[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
+									<textarea class="form-control" style="resize:vertical;" rows="3" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]></textarea>
+								</div>
 							</div>
-						</div>
+						[%/site_value%]
 						[%END PARAM%]
 					[%PARAM *short_text_option%]
 						<div class="col-xs-12 col-md-6">
@@ -154,6 +156,7 @@
 						</div>
 						[%END PARAM%]
 					[%END EXTRA_CUSTOMER_FIELDS%]
+						[%site_value id:'register_textareas' type:'load'/%]
 						<div class="clear"></div>
 						<div class="col-xs-12 col-md-12">
 							<div class="form-group">

--- a/src/templates/customer/login.template.html
+++ b/src/templates/customer/login.template.html
@@ -131,7 +131,7 @@
 							<div class="form-group">
 								<label for="[@field_id@]">[@field_name@]</label>
 								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<input class="datepicker" class="form-control" id="[@field_id@]" name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+								<input class="form-control datepicker" id="[@field_id@]" name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
 							</div>
 						</div>
 						[%END PARAM%]

--- a/src/templates/customer/mystore/edit.template.html
+++ b/src/templates/customer/mystore/edit.template.html
@@ -156,7 +156,7 @@
                         <div class="form-group">
                             <label for="[@field_id@]">[@field_name@]</label>
                             [%if [@required_field@]%]<span class="required text-danger">*</span>[%/if%]
-                            <input class="datepicker" class="form-control" id="[@field_id@]" name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+                            <input class="form-control datepicker" id="[@field_id@]" name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
                         </div>
                     </div>
                 [%END PARAM%]

--- a/src/templates/customer/register/template.html
+++ b/src/templates/customer/register/template.html
@@ -95,7 +95,7 @@
 							<div class="form-group">
 								<label for="[@field_id@]">[@field_name@]</label>
 								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+								<textarea class="form-control" rows="3" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]></textarea>
 							</div>
 						</div>
 						[%END PARAM%]

--- a/src/templates/customer/register/template.html
+++ b/src/templates/customer/register/template.html
@@ -95,7 +95,7 @@
 							<div class="form-group">
 								<label for="[@field_id@]">[@field_name@]</label>
 								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<textarea class="form-control" rows="3" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]></textarea>
+								<textarea class="form-control" style="resize:vertical;" rows="3" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]></textarea>
 							</div>
 						</div>
 						[%END PARAM%]

--- a/src/templates/customer/register/template.html
+++ b/src/templates/customer/register/template.html
@@ -79,83 +79,80 @@
 						</div>
 
 						[%EXTRA_CUSTOMER_FIELDS%]
-					[%PARAM *header%]
-						[%END PARAM%]
-					[%PARAM *integer_option%]
-						<div class="col-xs-12 col-md-6">
-							<div class="form-group">
-								<label for="[@field_id@]">[@field_name@]</label>
-								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
-							</div>
-						</div>
-						[%END PARAM%]
-					[%PARAM *text_option%]
-						[%site_value id:'register_textareas'%]
-							<div class="col-xs-12 col-md-12">
-								<div class="form-group">
-									<label for="[@field_id@]">[@field_name@]</label>
-									[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-									<textarea class="form-control" style="resize:vertical;" rows="3" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]></textarea>
+							[%PARAM *integer_option%]
+								<div class="col-xs-12 col-md-6">
+									<div class="form-group">
+										<label for="[@field_id@]">[@field_name@]</label>
+										[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
+										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+									</div>
 								</div>
-							</div>
-						[%/site_value%]
-						[%END PARAM%]
-					[%PARAM *short_text_option%]
-						<div class="col-xs-12 col-md-6">
-							<div class="form-group">
-								<label for="[@field_id@]">[@field_name@]</label>
-								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
-							</div>
-						</div>
-						[%END PARAM%]
-					[%PARAM *descimal_option%]
-						<div class="col-xs-12 col-md-6">
-							<div class="form-group">
-								<label for="[@field_id@]">[@field_name@]</label>
-								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
-							</div>
-						</div>
-						[%END PARAM%]
-					[%PARAM *boolean_option%]
-						[%site_value id:'register_checkboxes'%]
-							<div class="checkbox">
-								<label>
-									<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
-									[@field_name@]
-								</label>
-								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-							</div>
-						[%/site_value%]
-						[%END PARAM%]
-					[%PARAM *date_option%]
-						<div class="col-xs-12 col-md-6">
-							<div class="form-group">
-								<label for="[@field_id@]">[@field_name@]</label>
-								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<input class="form-control datepicker" id="[@field_id@]" name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
-							</div>
-						</div>
-						[%END PARAM%]
-					[%PARAM *selection_header%]
-						<div class="col-xs-12 col-md-6">
-							<div class="form-group">
-								<label for="[@field_id@]">[@field_name@]</label>
-								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<select id="[@field_id@]" name="[@field_id@]" class="form-control" [%if [@required_field@]%]required="true"[%/if%]>
-
-									[%END PARAM%]
-			[%PARAM *selection_body%]
-									<option value="[@option_value@]">[@option_value@]</option>
-									[%END PARAM%]
-			[%PARAM *selection_footer%]
-								</select>
-							</div>
-						</div>
-						[%END PARAM%]
-					[%END EXTRA_CUSTOMER_FIELDS%]
+							[%/PARAM%]
+							[%PARAM *text_option%]
+								[%site_value id:'register_textareas'%]
+									<div class="col-xs-12 col-md-12">
+										<div class="form-group">
+											<label for="[@field_id@]">[@field_name@]</label>
+											[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
+											<textarea class="form-control" style="resize:vertical;" rows="3" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]></textarea>
+										</div>
+									</div>
+								[%/site_value%]
+							[%/PARAM%]
+							[%PARAM *short_text_option%]
+								<div class="col-xs-12 col-md-6">
+									<div class="form-group">
+										<label for="[@field_id@]">[@field_name@]</label>
+										[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
+										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+									</div>
+								</div>
+							[%/PARAM%]
+							[%PARAM *descimal_option%]
+								<div class="col-xs-12 col-md-6">
+									<div class="form-group">
+										<label for="[@field_id@]">[@field_name@]</label>
+										[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
+										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+									</div>
+								</div>
+							[%/PARAM%]
+							[%PARAM *boolean_option%]
+								[%site_value id:'register_checkboxes'%]
+									<div class="checkbox">
+										<label>
+											<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
+											[@field_name@]
+										</label>
+										[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
+									</div>
+								[%/site_value%]
+							[%/PARAM%]
+							[%PARAM *date_option%]
+								<div class="col-xs-12 col-md-6">
+									<div class="form-group">
+										<label for="[@field_id@]">[@field_name@]</label>
+										[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
+										<input class="form-control datepicker" id="[@field_id@]" name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+									</div>
+								</div>
+							[%/PARAM%]
+							[%PARAM *selection_header%]
+								<div class="col-xs-12 col-md-6">
+									<div class="form-group">
+										<label for="[@field_id@]">[@field_name@]</label>
+										[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
+										<select id="[@field_id@]" name="[@field_id@]" class="form-control" [%if [@required_field@]%]required="true"[%/if%]>
+							[%/PARAM%]
+							[%PARAM *selection_body%]
+											<option value="[@option_value@]">[@option_value@]</option>
+							[%/PARAM%]
+							[%PARAM *selection_footer%]
+										</select>
+									</div>
+								</div>
+							[%/PARAM%]
+						[%/EXTRA_CUSTOMER_FIELDS%]
 						[%site_value id:'register_textareas' type:'load'/%]
 						<div class="clear"></div>
 						<div class="col-xs-12 col-md-12">

--- a/src/templates/customer/register/template.html
+++ b/src/templates/customer/register/template.html
@@ -118,13 +118,15 @@
 						</div>
 						[%END PARAM%]
 					[%PARAM *boolean_option%]
-						<div class="col-xs-12 col-md-6">
-							<div class="form-group">
-								<label for="[@field_id@]">[@field_name@]</label>
+						[%site_value id:'register_checkboxes'%]
+							<div class="checkbox">
+								<label>
+									<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
+									[@field_name@]
+								</label>
 								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<input type="checkbox" class="form-control" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
 							</div>
-						</div>
+						[%/site_value%]
 						[%END PARAM%]
 					[%PARAM *date_option%]
 						<div class="col-xs-12 col-md-6">
@@ -155,6 +157,7 @@
 						<div class="clear"></div>
 						<div class="col-xs-12 col-md-12">
 							<div class="form-group">
+								[%site_value id:'register_checkboxes' type:'load'/%]
 								<div class="checkbox">
 									<label>
 										<input name="regoptin" type="checkbox" value="Y" checked="checked" data-message="You can unsubscribe at any time."/>

--- a/src/templates/customer/register/template.html
+++ b/src/templates/customer/register/template.html
@@ -91,7 +91,7 @@
 						</div>
 						[%END PARAM%]
 					[%PARAM *text_option%]
-						<div class="col-xs-12 col-md-6">
+						<div class="col-xs-12 col-md-12">
 							<div class="form-group">
 								<label for="[@field_id@]">[@field_name@]</label>
 								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]

--- a/src/templates/customer/register/template.html
+++ b/src/templates/customer/register/template.html
@@ -91,13 +91,15 @@
 						</div>
 						[%END PARAM%]
 					[%PARAM *text_option%]
-						<div class="col-xs-12 col-md-12">
-							<div class="form-group">
-								<label for="[@field_id@]">[@field_name@]</label>
-								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<textarea class="form-control" style="resize:vertical;" rows="3" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]></textarea>
+						[%site_value id:'register_textareas'%]
+							<div class="col-xs-12 col-md-12">
+								<div class="form-group">
+									<label for="[@field_id@]">[@field_name@]</label>
+									[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
+									<textarea class="form-control" style="resize:vertical;" rows="3" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]></textarea>
+								</div>
 							</div>
-						</div>
+						[%/site_value%]
 						[%END PARAM%]
 					[%PARAM *short_text_option%]
 						<div class="col-xs-12 col-md-6">
@@ -154,6 +156,7 @@
 						</div>
 						[%END PARAM%]
 					[%END EXTRA_CUSTOMER_FIELDS%]
+						[%site_value id:'register_textareas' type:'load'/%]
 						<div class="clear"></div>
 						<div class="col-xs-12 col-md-12">
 							<div class="form-group">

--- a/src/templates/customer/register/template.html
+++ b/src/templates/customer/register/template.html
@@ -131,7 +131,7 @@
 							<div class="form-group">
 								<label for="[@field_id@]">[@field_name@]</label>
 								[%if [@required_field@]%]<span class="text-danger small">Required</span>[%/if%]
-								<input class="datepicker" class="form-control" id="[@field_id@]" name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+								<input class="form-control datepicker" id="[@field_id@]" name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
 							</div>
 						</div>
 						[%END PARAM%]

--- a/src/templates/customer/wholesaleregister/template.html
+++ b/src/templates/customer/wholesaleregister/template.html
@@ -208,7 +208,7 @@
 				[%if [@required_field@]%]<span style="color:red;">*</span>[%/if%]
 			</label>
 			<div class="col-sm-9">
-				<input class="datepicker" name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%END NOHTML%]" class="form-control" [%if [@required_field@]%]required[%/if%]>
+				<input name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%END NOHTML%]" class="form-control datepicker" [%if [@required_field@]%]required[%/if%]>
 			</div>
 		</div>
 	[%/param%]

--- a/src/templates/customer/wholesaleregister/template.html
+++ b/src/templates/customer/wholesaleregister/template.html
@@ -219,7 +219,7 @@
 				[%if [@required_field@]%]<span style="color:red;">*</span>[%/if%]
 			</label>
 			<div class="col-sm-9">
-				<select name="[@field_id@]" [%if [@required_field@]%]required[%/if%]>
+				<select name="[@field_id@]" class="form-control" [%if [@required_field@]%]required[%/if%]>
 					[%/param%]
 					[%param *selection_body%]
 						<option value="[@option_value@]">[@option_value@]</option>


### PR DESCRIPTION
# ⚡️ In progress ⚡️
- [x] Implement changes on customer register
- [ ] Implement changes on wholesale register

Change summary:
- Fix styling of custom date fields on register and wholesale register pages
- Fix styling of custom select fields on wholesale register pages
- Checkboxes look horrible - fix styling and group these together at the bottom of the register and wholesale register forms
- Long text custom fields should use textarea elements on the register and wholesale register forms and should also be grouped together 


## Before
Wholesale register (note the "test 4" date field and select boxes):
![image](https://user-images.githubusercontent.com/6867163/36766320-13ed1e68-1c81-11e8-89cd-f26e3949bee8.png)

Register (note the "test 4" date field):
![image](https://user-images.githubusercontent.com/6867163/36766310-09fc08ce-1c81-11e8-90d7-999c80f60228.png)