### PR TITLE
Fix issue where some orders may not be visible on my account page

### DIFF
--- a/src/templates/customer/template.html
+++ b/src/templates/customer/template.html
@@ -171,7 +171,7 @@
 <section class="col-xs-12" aria-label="My Orders">
 	<hr />
 	<h2 id="orders">My Orders</h2>
-	[%thumb_list type:'orders' limit:'10'%]
+	[%thumb_list type:'orders' limit:'9'%]
 		[%param filter_1%]
 			[%form id:'ord'/%]
 		[%/param%]
@@ -240,7 +240,7 @@
 		[%/param%]
 		[%param *footer%]
 			</div>
-			[%if [@total_results@] > 15%]
+			[%if [@total_results@] > 9%]
 				<div class="text-center">
 					<ul class="pagination" aria-label="Orders pagination navigation">
 						[%paging limit:'3'%]

--- a/src/templates/customer/template.html
+++ b/src/templates/customer/template.html
@@ -240,7 +240,7 @@
 		[%/param%]
 		[%param *footer%]
 			</div>
-			[%if [@total_results@] > 9%]
+			[%if [@total_results@] > [@limit@]%]
 				<div class="text-center">
 					<ul class="pagination" aria-label="Orders pagination navigation">
 						[%paging limit:'3'%]


### PR DESCRIPTION
There was an issue where the orders thumb_list was limited by 10 orders but pagination only kicked in after 15 orders, meaning in some situations a customer may not be able to see their full order history. 

This PR fixes that issue 🎉🎉🎉

I've also changed the limit on the orders thumb_list to 9 so that it doesn't leave an outlier in the 3 column layout. 