### PR TITLE
Content of terms pane shows as fancybox popup because of conflicting ID 

### DIFF
--- a/src/templates/products/template.html
+++ b/src/templates/products/template.html
@@ -236,8 +236,8 @@
 						<a href="#specifications" data-toggle="tab">Specifications</a>
 					</li>
 					[%if [@tnc@]%]
-						<li id="tabTerms" role="tab" aria-controls="terms" aria-selected="false">
-							<a href="#terms" data-toggle="tab">Terms and Conditions</a>
+						<li id="tabTermsConditions" role="tab" aria-controls="termsConditions" aria-selected="false">
+							<a href="#termsConditions" data-toggle="tab">Terms and Conditions</a>
 						</li>
 					[%/if%]
 					[%if [@config:show_product_reviews@]%]
@@ -274,7 +274,7 @@
 						</div>
 					[%/if%]
 					[%if [@tnc@]%]
-						<div role="tabpanel" aria-labelledby="tabTerms" class="tab-pane" id="terms">
+						<div role="tabpanel" aria-labelledby="tabTermsConditions" class="tab-pane" id="termsConditions">
 							<div class="n-responsive-content">
 								[@tnc@]
 							</div>


### PR DESCRIPTION
# Problem
![2018-03-07_11-10-58](https://user-images.githubusercontent.com/6867163/37068325-ce845282-21f9-11e8-9d3c-f27a826ad95e.gif)

# Cause
The terms and conditions panel's ID of `terms` conflicts with the following line in `custom.js`:
https://github.com/NetoECommerce/Skeletal/blob/ed380ac72370376b4e145f2ff4734d61a0bf6839/src/js/custom.js#L100-L104

# Solution
Changed the ID of the panel to `termsConditions` and updated corresponding aria attributes. 