### PR TITLE
Change Neto website link to netohq.com

### DIFF
--- a/src/templates/footers/checkout.template.html
+++ b/src/templates/footers/checkout.template.html
@@ -95,7 +95,7 @@
 					<strong>Copyright &copy; [%format type:'date' format:'#Y'%]today[%/format%] [@config:company_name@]</strong><br>
 					[%if [@config:company_abn@]%]<strong>[%if [@config:PRIMARY_ABN_LABEL@]%][@config:PRIMARY_ABN_LABEL@][%else%]ABN[%/if%]:</strong> [@config:company_abn@]<br>[%/ if%]
 					[%if [@config:company_poaddr@]%]<strong>Address:</strong> [@config:company_poaddr@][%/ if%]
-					[%if [@config:show_platform_branding@]%]<p class="small"><a href="https://www.netohq.com" title="Neto Retail Management Platform" target="_blank" rel="noopener">Ecommerce software by Neto</a></p>[%/if%]
+					[%if [@config:show_platform_branding@]%]<p class="small"><a href="https://www.netohq.com" title="Neto E-commerce Retail Management Platform" target="_blank" rel="noopener">E-commerce software by Neto</a></p>[%/if%]
 				</address>
 			</div>
 		</div>

--- a/src/templates/footers/template.html
+++ b/src/templates/footers/template.html
@@ -232,7 +232,7 @@
 					<strong>Copyright &copy; [%format type:'date' format:'#Y'%]today[%/format%] [@config:company_name@]</strong><br>
 					[%if [@config:company_abn@]%]<strong>[%if [@config:PRIMARY_ABN_LABEL@]%][@config:PRIMARY_ABN_LABEL@][%else%]ABN[%/if%]:</strong> [@config:company_abn@]<br>[%/ if%]
 					[%if [@config:company_poaddr@]%]<strong>Address:</strong> [@config:company_poaddr@][%/ if%]
-					[%if [@config:show_platform_branding@]%]<p class="small"><a href="https://www.netohq.com" title="Neto Retail Management Platform" target="_blank" rel="noopener">Ecommerce software by Neto</a></p>[%/if%]
+					[%if [@config:show_platform_branding@]%]<p class="small"><a href="https://www.netohq.com" title="Neto E-commerce Retail Management Platform" target="_blank" rel="noopener">E-commerce software by Neto</a></p>[%/if%]
 				</address>
 			</div>
 		</div>


### PR DESCRIPTION
Change Neto website link in footer from neto.com.au to netohq.com. Helps build backlinks to our new domain