### PR TITLE
Notify Me button does not show loading animation on variation switch

### DIFF
--- a/src/js/custom.js
+++ b/src/js/custom.js
@@ -112,13 +112,15 @@ $(document).ready(function() {
 
 });
 
-$(".btn-loads").click(function(){
+// Show button loading animation for 3 seconds
+function buttonLoading() {
 	$(this).button("loading");
 	var pendingbutton=this;
 	setTimeout(function(){
 		$(pendingbutton).button("reset");
 	},3000);
-});
+}
+$(".btn-loads").click(buttonLoading);
 
 // Fancybox
 $(document).ready(function() {

--- a/src/templates/products/includes/buying_options.template.html
+++ b/src/templates/products/includes/buying_options.template.html
@@ -109,13 +109,13 @@
 			</div>
 			<div class="col-xs-12 col-md-4">
 				[%IF [@store_quantity@] > 0 AND [@preorder@] %]
-				<button type="button" title="Add [@model@] to Cart" class="addtocart btn btn-warning btn-block btn-lg btn-loads" data-loading-text="<i class='fa fa-spinner fa-spin' style='font-size: 14px'></i>" rel="[@rndm@][@SKU@]"><i class="fa fa-clock-o icon-white" aria-hidden="true"></i> Pre-Order Now</button>
+				<button type="button" title="Add [@model@] to Cart" class="addtocart btn btn-warning btn-block btn-lg btn-loads btn-ajax-loads" data-loading-text="<i class='fa fa-spinner fa-spin' style='font-size: 14px'></i>" rel="[@rndm@][@SKU@]"><i class="fa fa-clock-o icon-white" aria-hidden="true"></i> Pre-Order Now</button>
 				[%ELSEIF [@store_quantity@] > 0 AND ![@preorder@] %]
-				<button type="button" title="Add [@model@] to Cart" class="addtocart btn btn-success btn-block btn-lg btn-loads" data-loading-text="<i class='fa fa-spinner fa-spin' style='font-size: 14px'></i>" rel="[@rndm@][@SKU@]"><i class="fa fa-shopping-cart icon-white" aria-hidden="true"></i> Add to Cart</button>
+				<button type="button" title="Add [@model@] to Cart" class="addtocart btn btn-success btn-block btn-lg btn-loads btn-ajax-loads" data-loading-text="<i class='fa fa-spinner fa-spin' style='font-size: 14px'></i>" rel="[@rndm@][@SKU@]"><i class="fa fa-shopping-cart icon-white" aria-hidden="true"></i> Add to Cart</button>
 				[%ELSEIF [@store_quantity@] < 1 AND [@config:ALLOW_NOSTOCK_CHECKOUT@] %]
-				<button type="button" title="Add [@model@] to Cart" class="addtocart btn btn-warning btn-block btn-lg btn-loads" data-loading-text="<i class='fa fa-spinner fa-spin' style='font-size: 14px'></i>" rel="[@rndm@][@SKU@]"><i class="fa fa-clock-o icon-white" aria-hidden="true"></i> Backorder</button>
+				<button type="button" title="Add [@model@] to Cart" class="addtocart btn btn-warning btn-block btn-lg btn-loads btn-ajax-loads" data-loading-text="<i class='fa fa-spinner fa-spin' style='font-size: 14px'></i>" rel="[@rndm@][@SKU@]"><i class="fa fa-clock-o icon-white" aria-hidden="true"></i> Backorder</button>
 				[%ELSE%]
-				<a class="btn btn-info btn-lg btn-block" title="Notify Me When [@model@] Is Back In Stock" data-toggle="modal" data-target="#notifymodal"><i class="fa fa-envelope" aria-hidden="true"></i> Notify Me</a>
+				<a class="btn btn-info btn-block btn-lg btn-loads btn-ajax-loads" data-loading-text="<i class='fa fa-spinner fa-spin' style='font-size: 14px'></i>" title="Notify Me When [@model@] Is Back In Stock" data-toggle="modal" data-target="#notifymodal"><i class="fa fa-envelope" aria-hidden="true"></i> Notify Me</a>
 				[%END IF%]
 			</div>
 			<div class="col-xs-12 col-md-4">

--- a/src/templates/products/includes/buying_options.template.html
+++ b/src/templates/products/includes/buying_options.template.html
@@ -109,13 +109,13 @@
 			</div>
 			<div class="col-xs-12 col-md-4">
 				[%IF [@store_quantity@] > 0 AND [@preorder@] %]
-				<button type="button" title="Add [@model@] to Cart" class="addtocart btn btn-warning btn-block btn-lg btn-loads btn-ajax-loads" data-loading-text="<i class='fa fa-spinner fa-spin' style='font-size: 14px'></i>" rel="[@rndm@][@SKU@]"><i class="fa fa-clock-o icon-white" aria-hidden="true"></i> Pre-Order Now</button>
+				<button type="button" title="Add [@model@] to Cart" class="addtocart btn btn-warning btn-block btn-lg btn-ajax-loads" data-loading-text="<i class='fa fa-spinner fa-spin' style='font-size: 14px'></i>" rel="[@rndm@][@SKU@]"><i class="fa fa-clock-o icon-white" aria-hidden="true"></i> Pre-Order Now</button>
 				[%ELSEIF [@store_quantity@] > 0 AND ![@preorder@] %]
-				<button type="button" title="Add [@model@] to Cart" class="addtocart btn btn-success btn-block btn-lg btn-loads btn-ajax-loads" data-loading-text="<i class='fa fa-spinner fa-spin' style='font-size: 14px'></i>" rel="[@rndm@][@SKU@]"><i class="fa fa-shopping-cart icon-white" aria-hidden="true"></i> Add to Cart</button>
+				<button type="button" title="Add [@model@] to Cart" class="addtocart btn btn-success btn-block btn-lg btn-ajax-loads" data-loading-text="<i class='fa fa-spinner fa-spin' style='font-size: 14px'></i>" rel="[@rndm@][@SKU@]"><i class="fa fa-shopping-cart icon-white" aria-hidden="true"></i> Add to Cart</button>
 				[%ELSEIF [@store_quantity@] < 1 AND [@config:ALLOW_NOSTOCK_CHECKOUT@] %]
-				<button type="button" title="Add [@model@] to Cart" class="addtocart btn btn-warning btn-block btn-lg btn-loads btn-ajax-loads" data-loading-text="<i class='fa fa-spinner fa-spin' style='font-size: 14px'></i>" rel="[@rndm@][@SKU@]"><i class="fa fa-clock-o icon-white" aria-hidden="true"></i> Backorder</button>
+				<button type="button" title="Add [@model@] to Cart" class="addtocart btn btn-warning btn-block btn-lg btn-ajax-loads" data-loading-text="<i class='fa fa-spinner fa-spin' style='font-size: 14px'></i>" rel="[@rndm@][@SKU@]"><i class="fa fa-clock-o icon-white" aria-hidden="true"></i> Backorder</button>
 				[%ELSE%]
-				<a class="btn btn-info btn-block btn-lg btn-loads btn-ajax-loads" data-loading-text="<i class='fa fa-spinner fa-spin' style='font-size: 14px'></i>" title="Notify Me When [@model@] Is Back In Stock" data-toggle="modal" data-target="#notifymodal"><i class="fa fa-envelope" aria-hidden="true"></i> Notify Me</a>
+				<a class="btn btn-info btn-block btn-lg btn-ajax-loads" data-loading-text="<i class='fa fa-spinner fa-spin' style='font-size: 14px'></i>" title="Notify Me When [@model@] Is Back In Stock" data-toggle="modal" data-target="#notifymodal"><i class="fa fa-envelope" aria-hidden="true"></i> Notify Me</a>
 				[%END IF%]
 			</div>
 			<div class="col-xs-12 col-md-4">

--- a/src/templates/products/includes/product_scripts.template.html
+++ b/src/templates/products/includes/product_scripts.template.html
@@ -5,11 +5,11 @@
 				'loadtmplates': ['_buying_options', '_images','_header'],
 				'fns' : {
 					'onLoad' : function () {
-						$('.addtocart').button("loading");
+						$('.btn-ajax-loads').button("loading");
 						$('.variation-wrapper').addClass('disable-interactivity');
 					},
 					'onReady' : function () {
-						$('.addtocart').button("reset");
+						$('.btn-ajax-loads').button("reset");
 						$('.zoom').zoom();
 						$('.variation-wrapper').removeClass('disable-interactivity');
 						$("#sale-end").countdown({

--- a/src/templates/products/includes/product_scripts.template.html
+++ b/src/templates/products/includes/product_scripts.template.html
@@ -10,7 +10,6 @@
 					},
 					'onReady' : function () {
 						$('.btn-ajax-loads').button("reset");
-						$(".btn-ajax-loads").click(buttonLoading);
 						$('.zoom').zoom();
 						$('.variation-wrapper').removeClass('disable-interactivity');
 						$("#sale-end").countdown({
@@ -49,6 +48,7 @@
 				tabpan.attr("aria-hidden","false");  // show our panel
 			 });
 		})
+		$(document).on("click", ".btn-ajax-loads", buttonLoading);
 		$('#_jstl__buying_options').on('click', '.wishlist_toggle', function(e){e.preventDefault();})
 	</script>
 [%/site_value%]

--- a/src/templates/products/includes/product_scripts.template.html
+++ b/src/templates/products/includes/product_scripts.template.html
@@ -10,6 +10,13 @@
 					},
 					'onReady' : function () {
 						$('.btn-ajax-loads').button("reset");
+						$(".btn-ajax-loads").click(function(){
+							$(this).button("loading");
+							var pendingbutton=this;
+							setTimeout(function(){
+								$(pendingbutton).button("reset");
+							},3000);
+						});
 						$('.zoom').zoom();
 						$('.variation-wrapper').removeClass('disable-interactivity');
 						$("#sale-end").countdown({

--- a/src/templates/products/includes/product_scripts.template.html
+++ b/src/templates/products/includes/product_scripts.template.html
@@ -10,13 +10,7 @@
 					},
 					'onReady' : function () {
 						$('.btn-ajax-loads').button("reset");
-						$(".btn-ajax-loads").click(function(){
-							$(this).button("loading");
-							var pendingbutton=this;
-							setTimeout(function(){
-								$(pendingbutton).button("reset");
-							},3000);
-						});
+						$(".btn-ajax-loads").click(buttonLoading);
 						$('.zoom').zoom();
 						$('.variation-wrapper').removeClass('disable-interactivity');
 						$("#sale-end").countdown({


### PR DESCRIPTION
## Problem:
- Notify Me button would not display loading spinner when switching variations on the product page, even though the other button styles would
- When switching variations on the product page, all `.addtocart` classed buttons spin (including the buttons on product thumbs at the bottom of the page)

## Solution:
- Changed the `$('.addtocart').button("loading")` function to use a more specific class - `.btn-ajax-loads`
- Added loading animation to Notify Me button when switching variations 