### PR TITLE
Shopping Cart not showing PRE-ORDER status on Kit Components

### DIFF
--- a/src/templates/cart/shopping_cart.template.html
+++ b/src/templates/cart/shopping_cart.template.html
@@ -67,7 +67,10 @@
 									[%param *body%]
 										<li>
 											<input type="hidden" name="compsku[@count@]_[@component_count@]" value="[@SKU@]">
-											<label>[@model@] x </label>
+											<label>[@model@] x </label><br />
+											[%if [@preorder@]%]
+										        	<span class="label label-warning">On pre-order - Released [%format type:'date'%][@arrival_date@][%/format%]</span><br />
+										    	[%/if%]
 											<input type="number" min="[@min_assemble@]" max="[@max_assemble@]" name="compqty[@count@]_[@component_count@]" class="form-control [%if [@fixed_assemble@]%]readonly [%/if%]" [%if [@fixed_assemble@]%]readonly [%/if%] value="[@qty@]" size="3">
 										</li>
 									[%/param%]

--- a/src/templates/cart/shopping_cart.template.html
+++ b/src/templates/cart/shopping_cart.template.html
@@ -67,10 +67,7 @@
 									[%param *body%]
 										<li>
 											<input type="hidden" name="compsku[@count@]_[@component_count@]" value="[@SKU@]">
-											<label>[@model@] x </label><br />
-											[%if [@preorder@]%]
-										        	<span class="label label-warning">On pre-order - Released [%format type:'date'%][@arrival_date@][%/format%]</span><br />
-										    	[%/if%]
+											<label>[@model@] x  <br>[%if [@preorder@]%]<span class="label label-warning">On pre-order - Released [%format type:'date'%][@arrival_date@][%/format%]</span>[%/if%]</label>
 											<input type="number" min="[@min_assemble@]" max="[@max_assemble@]" name="compqty[@count@]_[@component_count@]" class="form-control [%if [@fixed_assemble@]%]readonly [%/if%]" [%if [@fixed_assemble@]%]readonly [%/if%] value="[@qty@]" size="3">
 										</li>
 									[%/param%]

--- a/src/templates/cart/shopping_cart.template.html
+++ b/src/templates/cart/shopping_cart.template.html
@@ -67,7 +67,7 @@
 									[%param *body%]
 										<li>
 											<input type="hidden" name="compsku[@count@]_[@component_count@]" value="[@SKU@]">
-											<label>[@model@] x  <br>[%if [@preorder@]%]<span class="label label-warning">On pre-order - Released [%format type:'date'%][@arrival_date@][%/format%]</span>[%/if%]</label>
+											<label>[@model@] x [%if [@preorder@]%]<br /><span class="label label-warning">On pre-order - Released [%format type:'date'%][@arrival_date@][%/format%]</span>[%/if%]</label>
 											<input type="number" min="[@min_assemble@]" max="[@max_assemble@]" name="compqty[@count@]_[@component_count@]" class="form-control [%if [@fixed_assemble@]%]readonly [%/if%]" [%if [@fixed_assemble@]%]readonly [%/if%] value="[@qty@]" size="3">
 										</li>
 									[%/param%]


### PR DESCRIPTION
Oddly the pre-order status doesn't show on the [@has_components@] section on line 62, contrary to the if-statement above it that suggests it should.

This change adds the pre-order status below the appropriate component label. Putting it above looks confusing next to all the other components.

Solves #390