### PR TITLE
login/register/wholesaleregister form updates

### DIFF
--- a/src/templates/customer/login.template.html
+++ b/src/templates/customer/login.template.html
@@ -1,15 +1,15 @@
 <div class="col-12">
 	<div class="page-header"><h1>My Account</h1></div>
-	[%TRIM inner:'1'%]
+	[%trim inner:'1'%]
 		[%param body%]
 		[%show_message severity:'error'%]
-			[%param *body%]<div class="alert alert-danger" role="alert"><a class="close" data-dismiss="alert">×</a><i class="fa fa-exclamation-triangle"></i> [@info_msg@]</div>[%/ param%]
-		[%/ show_message%]
-		[%/ param%]
-	[%/ TRIM%]
+			[%param *body%]<div class="alert alert-danger" role="alert"><a class="close" data-dismiss="alert">×</a><i class="fa fa-exclamation-triangle"></i> [@info_msg@]</div>[%/param%]
+		[%/show_message%]
+		[%/param%]
+	[%/trim%]
 	<div class="row">
 		<div class="col-12 col-md-6">
-			<form id="login" method="post" action="[%URL page:'account' type:'login'%][%/ URL%]">
+			<form id="login" method="post" action="[%url page:'account' type:'login'%][%/url%]">
 				<input type="hidden" name="redirect" value="[@redirect@]">
 				<div class="card">
 					<div class="card-body border-bottom"><h3 class="card-title">Returning Customer? Log In. </h3></div>
@@ -19,14 +19,14 @@
 								<div class="form-group ">
 									<label for="username">My E-mail Address is</label>
 									<input type="text" id="username" name="username" class="form-control" value="[%nohtml%][@username@][%end nohtml%]" size="25" placeholder="name@example.com" required/>
-									<p class="form-text text-muted small d-none"><i class="fa fa-question-circle"></i> Forgot Your Username <a href="[%URL page:'account' type:'forgotusr'%][%/ URL%]">Click Here</a></p>
+									<p class="form-text text-muted small d-none"><i class="fa fa-question-circle"></i> Forgot Your Username <a href="[%url page:'account' type:'forgotusr'%][%/url%]">Click Here</a></p>
 								</div>
 							</div>
 							<div class="col-12 col-md-6">
 								<div class="form-group">
 									<label for="password">My Password is</label>
 									<input type="password" id="password" name="password" class="form-control" value="[%nohtml%][%end nohtml%]" size="25" autocomplete="off" required/>
-									<p class="form-text text-muted small"><i class="fa fa-question-circle"></i> Forgot Your Password <a href="[%URL page:'account' type:'forgotpwd'%][%/ URL%]" aria-label="Click if you forgot your password">Click Here</a></p>
+									<p class="form-text text-muted small"><i class="fa fa-question-circle"></i> Forgot Your Password <a href="[%url page:'account' type:'forgotpwd'%][%/url%]" aria-label="Click if you forgot your password">Click Here</a></p>
 								</div>
 							</div>
 						</div>
@@ -36,10 +36,10 @@
 			</form>
 		</div>
 		<div class="col-12 col-md-6">
-			<form id="register" method="post" action="[%URL page:'account' type:'register'%][%/ URL%]">
-				[%SUBMIT_TOKEN%][%/ SUBMIT_TOKEN%]
+			<form id="register" method="post" action="[%url page:'account' type:'register'%][%/url%]">
+				[%SUBMIT_TOKEN%][%/SUBMIT_TOKEN%]
 				<input type="hidden" name="redirect" value="[@redirect@]">
-				<input type="hidden" name="reg_username" value="[%format type:'date' format:'#h#i#s'%]now[%/ format%][%random_number length:'6'%][%/ random_number%]">
+				<input type="hidden" name="reg_username" value="[%format type:'date' format:'#h#i#s'%]now[%/format%][%random_number length:'6'%][%/random_number%]">
 				<div class="card">
 					<div class="card-body border-bottom"><h3 class="card-title">New Customer? Create an Account.</h3></div>
 					<div class="card-body">
@@ -47,7 +47,7 @@
 							<div class="col-12 col-md-12">
 								<div class="form-group">
 									<label for="reg_email">E-mail Address</label>
-									<input class="form-control" type="email" id="reg_email" name="reg_email" value="[%nohtml%][%FORM id:'reg_email'%][%/ FORM%][%end nohtml%]" size="25" required/>
+									<input class="form-control" type="email" id="reg_email" name="reg_email" value="[%nohtml%][%FORM id:'reg_email'%][%/FORM%][%end nohtml%]" size="25" required/>
 								</div>
 							</div>
 							<div class="col-12 col-md-6">
@@ -62,80 +62,86 @@
 									<input class="form-control" type="password" id="reg_password2" name="reg_password2" value="[%nohtml%][%end nohtml%]" size="25" autocomplete="off" required/>
 								</div>
 							</div>
-							[%EXTRA_CUSTOMER_FIELDS%]
+							[%extra_customer_fields%]
 							[%param *integer_option%]
 								<div class="col-12 col-md-6">
 									<div class="form-group">
 										<label for="[@field_id@]">[@field_name@]</label>
 										[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
-										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@default_value@][%/ NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@default_value@][%/NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
 									</div>
 								</div>
-							[%/ param%]
+							[%/param%]
 							[%param *text_option%]
-								<div class="col-12 col-md-6">
-									<div class="form-group">
-										<label for="[@field_id@]">[@field_name@]</label>
-										[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
-										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%/ NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+								[%site_value id:'register_textareas'%]
+									<div class="col-12">
+										<div class="form-group">
+											<label for="[@field_id@]">[@field_name@]</label>
+											[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
+											<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%/NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+										</div>
 									</div>
-								</div>
-							[%/ param%]
+								[%/site_value%]
+							[%/param%]
 							[%param *short_text_option%]
 								<div class="col-12 col-md-6">
 									<div class="form-group">
 										<label for="[@field_id@]">[@field_name@]</label>
 										[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
-										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%/ NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%/NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
 									</div>
 								</div>
-							[%/ param%]
+							[%/param%]
 							[%param *descimal_option%]
 								<div class="col-12 col-md-6">
 									<div class="form-group">
 										<label for="[@field_id@]">[@field_name@]</label>
 										[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
-										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@default_value@][%/ NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@default_value@][%/NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
 									</div>
 								</div>
-							[%/ param%]
+							[%/param%]
 							[%param *boolean_option%]
-								<div class="col-12 col-md-6">
-									<div class="form-group">
-										<label for="[@field_id@]">[@field_name@]</label>
+								[%site_value id:'register_checkboxes'%]
+									<div class="checkbox">
+										<label>
+											<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
+											[@field_name@]
+										</label>
 										[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
-										<input type="checkbox" class="form-control" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%/ DATA%] [%if [@required_field@]%]required="true"[%/if%]>
 									</div>
-								</div>
-							[%/ param%]
+								[%/site_value%]
+							[%/param%]
 							[%param *date_option%]
 								<div class="col-12 col-md-6">
 									<div class="form-group">
 										<label for="[@field_id@]">[@field_name@]</label>
 										[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
-										<input class="datepicker" class="form-control" id="[@field_id@]" name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%/ NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+										<input class="form-control datepicker" id="[@field_id@]" name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%/NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
 									</div>
 								</div>
-							[%/ param%]
+							[%/param%]
 							[%param *selection_header%]
 								<div class="col-12 col-md-6">
 									<div class="form-group">
 										<label for="[@field_id@]">[@field_name@]</label>
 										[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
 										<select id="[@field_id@]" name="[@field_id@]" class="form-control" [%if [@required_field@]%]required="true"[%/if%]>
-							[%/ param%]
+							[%/param%]
 							[%param *selection_body%]
 										<option value="[@option_value@]">[@option_value@]</option>
-							[%/ param%]
+							[%/param%]
 							[%param *selection_footer%]
 										</select>
 									</div>
 								</div>
-							[%/ param%]
-							[%/ EXTRA_CUSTOMER_FIELDS%]
+							[%/param%]
+							[%/extra_customer_fields%]
+							[%site_value id:'register_textareas' type:'load'/%]
 							<div class="clear"></div>
 							<div class="col-12">
 								<div class="form-group">
+									[%site_value id:'register_checkboxes' type:'load'/%]
 									<div class="checkbox">
 										<label>
 											<input name="regoptin" type="checkbox" value="Y" checked="checked" data-message="You can unsubscribe at any time."/>
@@ -157,4 +163,4 @@
 		</div>
 	</div>
 </div>
-[%GA_FUNNEL%]/user/login.html[%/ GA_FUNNEL%]
+[%GA_FUNNEL%]/user/login.html[%/GA_FUNNEL%]

--- a/src/templates/customer/login.template.html
+++ b/src/templates/customer/login.template.html
@@ -103,13 +103,11 @@
 							[%/param%]
 							[%param *boolean_option%]
 								[%site_value id:'register_checkboxes'%]
-									<div class="checkbox">
-										<label>
-											<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
-											[@field_name@]
-										</label>
+									<label class="d-block">
+										<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
+										[@field_name@]
 										[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
-									</div>
+									</label>
 								[%/site_value%]
 							[%/param%]
 							[%param *date_option%]
@@ -140,15 +138,12 @@
 							[%site_value id:'register_textareas' type:'load'/%]
 							<div class="clear"></div>
 							<div class="col-12">
-								<div class="form-group">
-									[%site_value id:'register_checkboxes' type:'load'/%]
-									<div class="checkbox">
-										<label>
-											<input name="regoptin" type="checkbox" value="Y" checked="checked" data-message="You can unsubscribe at any time."/>
-											Subscribe To Newsletter
-										</label>
-									</div>
-								</div>
+								[%site_value id:'register_checkboxes' type:'load'/%]
+								<label class="d-block">
+									<input name="regoptin" type="checkbox" value="Y" checked="checked" data-message="You can unsubscribe at any time."/>
+									Subscribe To Newsletter
+									<span class="text-muted small">optional</span>
+								</label>
 							</div>
 							<div class="col-12">
 								<div class="form-group">

--- a/src/templates/customer/login.template.html
+++ b/src/templates/customer/login.template.html
@@ -78,7 +78,7 @@
 										<div class="form-group">
 											<label for="[@field_id@]">[@field_name@]</label>
 											[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
-											<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%/NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+											<textarea class="form-control" rows="3" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%/NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]></textarea>
 										</div>
 									</div>
 								[%/site_value%]

--- a/src/templates/customer/login.template.html
+++ b/src/templates/customer/login.template.html
@@ -137,7 +137,7 @@
 							[%/extra_customer_fields%]
 							[%site_value id:'register_textareas' type:'load'/%]
 							<div class="clear"></div>
-							<div class="col-12">
+							<div class="col-12 form-group">
 								[%site_value id:'register_checkboxes' type:'load'/%]
 								<label class="d-block">
 									<input name="regoptin" type="checkbox" value="Y" checked="checked" data-message="You can unsubscribe at any time."/>

--- a/src/templates/customer/register/template.html
+++ b/src/templates/customer/register/template.html
@@ -1,15 +1,15 @@
 <div class="col-12">
 	<div class="page-header"><h1>My Account</h1></div>
-	[%TRIM inner:'1'%]
+	[%trim inner:'1'%]
 		[%param body%]
 		[%show_message severity:'error'%]
-			[%param *body%]<div class="alert alert-danger" role="alert"><a class="close" data-dismiss="alert">×</a><i class="fa fa-exclamation-triangle"></i> [@info_msg@]</div>[%/ param%]
-		[%/ show_message%]
-		[%/ param%]
-	[%/ TRIM%]
+			[%param *body%]<div class="alert alert-danger" role="alert"><a class="close" data-dismiss="alert">×</a><i class="fa fa-exclamation-triangle"></i> [@info_msg@]</div>[%/param%]
+		[%/show_message%]
+		[%/param%]
+	[%/trim%]
 	<div class="row">
 		<div class="col-12 col-md-6">
-			<form id="login" method="post" action="[%URL page:'account' type:'login'%][%/ URL%]">
+			<form id="login" method="post" action="[%url page:'account' type:'login'%][%/url%]">
 				<input type="hidden" name="redirect" value="[@redirect@]">
 				<div class="card">
 					<div class="card-body border-bottom"><h3 class="card-title">Returning Customer? Log In. </h3></div>
@@ -19,14 +19,14 @@
 								<div class="form-group ">
 									<label for="username">My E-mail Address is</label>
 									<input type="text" id="username" name="username" class="form-control" value="[%nohtml%][@username@][%end nohtml%]" size="25" placeholder="name@example.com" required/>
-									<p class="form-text text-muted small d-none"><i class="fa fa-question-circle"></i> Forgot Your Username <a href="[%URL page:'account' type:'forgotusr'%][%/ URL%]">Click Here</a></p>
+									<p class="form-text text-muted small d-none"><i class="fa fa-question-circle"></i> Forgot Your Username <a href="[%url page:'account' type:'forgotusr'%][%/url%]">Click Here</a></p>
 								</div>
 							</div>
 							<div class="col-12 col-md-6">
 								<div class="form-group">
 									<label for="password">My Password is</label>
 									<input type="password" id="password" name="password" class="form-control" value="[%nohtml%][%end nohtml%]" size="25" autocomplete="off" required/>
-									<p class="form-text text-muted small"><i class="fa fa-question-circle"></i> Forgot Your Password <a href="[%URL page:'account' type:'forgotpwd'%][%/ URL%]" aria-label="Click if you forgot your password">Click Here</a></p>
+									<p class="form-text text-muted small"><i class="fa fa-question-circle"></i> Forgot Your Password <a href="[%url page:'account' type:'forgotpwd'%][%/url%]" aria-label="Click if you forgot your password">Click Here</a></p>
 								</div>
 							</div>
 						</div>
@@ -36,10 +36,10 @@
 			</form>
 		</div>
 		<div class="col-12 col-md-6">
-			<form id="register" method="post" action="[%URL page:'account' type:'register'%][%/ URL%]">
-				[%SUBMIT_TOKEN%][%/ SUBMIT_TOKEN%]
+			<form id="register" method="post" action="[%url page:'account' type:'register'%][%/url%]">
+				[%SUBMIT_TOKEN%][%/SUBMIT_TOKEN%]
 				<input type="hidden" name="redirect" value="[@redirect@]">
-				<input type="hidden" name="reg_username" value="[%format type:'date' format:'#h#i#s'%]now[%/ format%][%random_number length:'6'%][%/ random_number%]">
+				<input type="hidden" name="reg_username" value="[%format type:'date' format:'#h#i#s'%]now[%/format%][%random_number length:'6'%][%/random_number%]">
 				<div class="card">
 					<div class="card-body border-bottom"><h3 class="card-title">New Customer? Create an Account.</h3></div>
 					<div class="card-body">
@@ -47,7 +47,7 @@
 							<div class="col-12 col-md-12">
 								<div class="form-group">
 									<label for="reg_email">E-mail Address</label>
-									<input class="form-control" type="email" id="reg_email" name="reg_email" value="[%nohtml%][%FORM id:'reg_email'%][%/ FORM%][%end nohtml%]" size="25" required/>
+									<input class="form-control" type="email" id="reg_email" name="reg_email" value="[%nohtml%][%FORM id:'reg_email'%][%/FORM%][%end nohtml%]" size="25" required/>
 								</div>
 							</div>
 							<div class="col-12 col-md-6">
@@ -62,80 +62,86 @@
 									<input class="form-control" type="password" id="reg_password2" name="reg_password2" value="[%nohtml%][%end nohtml%]" size="25" autocomplete="off" required/>
 								</div>
 							</div>
-							[%EXTRA_CUSTOMER_FIELDS%]
+							[%extra_customer_fields%]
 							[%param *integer_option%]
 								<div class="col-12 col-md-6">
 									<div class="form-group">
 										<label for="[@field_id@]">[@field_name@]</label>
 										[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
-										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@default_value@][%/ NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@default_value@][%/NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
 									</div>
 								</div>
-							[%/ param%]
+							[%/param%]
 							[%param *text_option%]
-								<div class="col-12 col-md-6">
-									<div class="form-group">
-										<label for="[@field_id@]">[@field_name@]</label>
-										[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
-										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%/ NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+								[%site_value id:'register_textareas'%]
+									<div class="col-12">
+										<div class="form-group">
+											<label for="[@field_id@]">[@field_name@]</label>
+											[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
+											<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%/NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+										</div>
 									</div>
-								</div>
-							[%/ param%]
+								[%/site_value%]
+							[%/param%]
 							[%param *short_text_option%]
 								<div class="col-12 col-md-6">
 									<div class="form-group">
 										<label for="[@field_id@]">[@field_name@]</label>
 										[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
-										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%/ NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%/NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
 									</div>
 								</div>
-							[%/ param%]
+							[%/param%]
 							[%param *descimal_option%]
 								<div class="col-12 col-md-6">
 									<div class="form-group">
 										<label for="[@field_id@]">[@field_name@]</label>
 										[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
-										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@default_value@][%/ NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+										<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@default_value@][%/NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
 									</div>
 								</div>
-							[%/ param%]
+							[%/param%]
 							[%param *boolean_option%]
-								<div class="col-12 col-md-6">
-									<div class="form-group">
-										<label for="[@field_id@]">[@field_name@]</label>
+								[%site_value id:'register_checkboxes'%]
+									<div class="checkbox">
+										<label>
+											<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
+											[@field_name@]
+										</label>
 										[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
-										<input type="checkbox" class="form-control" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%/ DATA%] [%if [@required_field@]%]required="true"[%/if%]>
 									</div>
-								</div>
-							[%/ param%]
+								[%/site_value%]
+							[%/param%]
 							[%param *date_option%]
 								<div class="col-12 col-md-6">
 									<div class="form-group">
 										<label for="[@field_id@]">[@field_name@]</label>
 										[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
-										<input class="datepicker" class="form-control" id="[@field_id@]" name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%/ NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+										<input class="form-control datepicker" id="[@field_id@]" name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%/NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
 									</div>
 								</div>
-							[%/ param%]
+							[%/param%]
 							[%param *selection_header%]
 								<div class="col-12 col-md-6">
 									<div class="form-group">
 										<label for="[@field_id@]">[@field_name@]</label>
 										[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
 										<select id="[@field_id@]" name="[@field_id@]" class="form-control" [%if [@required_field@]%]required="true"[%/if%]>
-							[%/ param%]
+							[%/param%]
 							[%param *selection_body%]
 										<option value="[@option_value@]">[@option_value@]</option>
-							[%/ param%]
+							[%/param%]
 							[%param *selection_footer%]
 										</select>
 									</div>
 								</div>
-							[%/ param%]
-							[%/ EXTRA_CUSTOMER_FIELDS%]
+							[%/param%]
+							[%/extra_customer_fields%]
+							[%site_value id:'register_textareas' type:'load'/%]
 							<div class="clear"></div>
 							<div class="col-12">
 								<div class="form-group">
+									[%site_value id:'register_checkboxes' type:'load'/%]
 									<div class="checkbox">
 										<label>
 											<input name="regoptin" type="checkbox" value="Y" checked="checked" data-message="You can unsubscribe at any time."/>
@@ -157,4 +163,4 @@
 		</div>
 	</div>
 </div>
-[%GA_FUNNEL%]/user/login.html[%/ GA_FUNNEL%]
+[%GA_FUNNEL%]/user/login.html[%/GA_FUNNEL%]

--- a/src/templates/customer/register/template.html
+++ b/src/templates/customer/register/template.html
@@ -103,13 +103,11 @@
 							[%/param%]
 							[%param *boolean_option%]
 								[%site_value id:'register_checkboxes'%]
-									<div class="checkbox">
-										<label>
-											<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
-											[@field_name@]
-										</label>
+									<label class="d-block">
+										<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
+										[@field_name@]
 										[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
-									</div>
+									</label>
 								[%/site_value%]
 							[%/param%]
 							[%param *date_option%]
@@ -140,15 +138,12 @@
 							[%site_value id:'register_textareas' type:'load'/%]
 							<div class="clear"></div>
 							<div class="col-12">
-								<div class="form-group">
-									[%site_value id:'register_checkboxes' type:'load'/%]
-									<div class="checkbox">
-										<label>
-											<input name="regoptin" type="checkbox" value="Y" checked="checked" data-message="You can unsubscribe at any time."/>
-											Subscribe To Newsletter
-										</label>
-									</div>
-								</div>
+								[%site_value id:'register_checkboxes' type:'load'/%]
+								<label class="d-block">
+									<input name="regoptin" type="checkbox" value="Y" checked="checked" data-message="You can unsubscribe at any time."/>
+									Subscribe To Newsletter
+									<span class="text-muted small">optional</span>
+								</label>
 							</div>
 							<div class="col-12">
 								<div class="form-group">

--- a/src/templates/customer/register/template.html
+++ b/src/templates/customer/register/template.html
@@ -78,7 +78,7 @@
 										<div class="form-group">
 											<label for="[@field_id@]">[@field_name@]</label>
 											[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
-											<input type="text" class="form-control" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%/NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]>
+											<textarea class="form-control" rows="3" id="[@field_id@]" name="[@field_id@]" value="[%NOHTML%][@field_default@][%/NOHTML%]" [%if [@required_field@]%]required="true"[%/if%]></textarea>
 										</div>
 									</div>
 								[%/site_value%]

--- a/src/templates/customer/register/template.html
+++ b/src/templates/customer/register/template.html
@@ -137,7 +137,7 @@
 							[%/extra_customer_fields%]
 							[%site_value id:'register_textareas' type:'load'/%]
 							<div class="clear"></div>
-							<div class="col-12">
+							<div class="col-12 form-group">
 								[%site_value id:'register_checkboxes' type:'load'/%]
 								<label class="d-block">
 									<input name="regoptin" type="checkbox" value="Y" checked="checked" data-message="You can unsubscribe at any time."/>

--- a/src/templates/customer/wholesaleregister/template.html
+++ b/src/templates/customer/wholesaleregister/template.html
@@ -252,6 +252,14 @@
 				</div>
 			[%/param%]
 		[%/extra_customer_fields%]
+		<div class="form-group">
+			[%site_value id:'register_checkboxes' type:'load'/%]
+			<label class="d-block">
+				<input type="checkbox" name="regoptin" value="Y" [%FORM id:'regoptin' if:'eq' value:'Y'%]checked[%END FORM%]> 
+				Subscribe to the [@config:company_name@] newsletter
+				<span class="text-muted small">optional</span>
+			</label>
+		</div>
 
 		<div class="form-group">
 			<h3 class="my-4">Terms &amp; Conditions Of Trade</h3>
@@ -261,12 +269,6 @@
 		</div>
 
 		<div class="form-group">
-			[%site_value id:'register_checkboxes' type:'load'/%]
-			<label class="d-block">
-				<input type="checkbox" name="regoptin" value="Y" [%FORM id:'regoptin' if:'eq' value:'Y'%]checked[%END FORM%]> 
-				Subscribe to the [@config:company_name@] newsletter
-				<span class="text-muted small">optional</span>
-			</label>
 			<label class="d-block">
 				<input type="checkbox" name="agree" value="y" required>
 				I agree to the [@config:company_name@] Terms &amp; Conditions Of Trade

--- a/src/templates/customer/wholesaleregister/template.html
+++ b/src/templates/customer/wholesaleregister/template.html
@@ -188,7 +188,7 @@
 						[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
 					</div>
 					<div class="col-md-9">
-						<textarea name="[@field_id@]" id="[@field_id@]" class="form-control" cols="20" [%if [@required_field@]%]required[%/if%]>[%NOHTML%][@field_default@][%END NOHTML%]</textarea>
+						<textarea name="[@field_id@]" id="[@field_id@]" class="form-control" rows="3" [%if [@required_field@]%]required[%/if%]>[%NOHTML%][@field_default@][%END NOHTML%]</textarea>
 					</div>
 				</div>
 			[%/param%]

--- a/src/templates/customer/wholesaleregister/template.html
+++ b/src/templates/customer/wholesaleregister/template.html
@@ -225,7 +225,7 @@
 	[%/param%]
 [%/extra_customer_fields%]
 
-<div>
+<div class="form-group">
 	<h3>&nbsp;Terms &amp; Conditions Of Trade</h3>
 	<div style="width:100%; border:1px solid #CCCCCC; height: 150px; overflow:scroll; text-align:left; padding:10px;">
 		[%content_zone id:'wholesale_terms'%][%end content_zone%]

--- a/src/templates/customer/wholesaleregister/template.html
+++ b/src/templates/customer/wholesaleregister/template.html
@@ -1,284 +1,280 @@
 <div class="col-12">
-<h1>Wholesale Registration Form</h1>
-<p>If you already have an account with us, please login at the <a href="[%url page:'account' type:'login'%][%END url%]">login page</a>.</p>
+	<h1>Wholesale Registration Form</h1>
+	<p>If you already have an account with us, please login at the <a href="[%url page:'account' type:'login'%][%END url%]">login page</a>.</p>
 
-[%TRIM inner:'1'%]
-[%PARAM body%]
-	[%show_message severity:'error'%]
-		[%PARAM *body%]<div class="alert alert-danger" role="alert"><a class="close" data-dismiss="alert">×</a>[@info_msg@]</div>[%/ PARAM%]
-	[%/ show_message%]
-[%/ PARAM%]
-[%/ TRIM%]
+	[%TRIM inner:'1'%]
+	[%PARAM body%]
+		[%show_message severity:'error'%]
+			[%PARAM *body%]<div class="alert alert-danger" role="alert"><a class="close" data-dismiss="alert">×</a>[@info_msg@]</div>[%/ PARAM%]
+		[%/ show_message%]
+	[%/ PARAM%]
+	[%/ TRIM%]
 
-<form name="adduser" id="adduser" method="POST" action="[%url page:'account' type:'wholesaleregister'%][%END url%]" class="form-horizontal">
-	[%SUBMIT_TOKEN%][%END SUBMIT_TOKEN%]
-	<input type="hidden" name="fn" value="proc">
-	<input type="hidden" name="redirect" value="[@redirect@]">
-<div class="">
-	<h3>Your Future Login Details</h3>
-	<div class="form-group row">
-		<div class="col-md-3">
-			<label for="">Username</label>
-		</div>
-		<div class="col-md-9">
-			<input type="text"  name="reg_username" size="20" maxlength="15" value="[%nohtml%][%FORM id:'reg_username'%][%END FORM%][%end nohtml%]" class="form-control" required>
-			<p class="text-muted small">(used for future access to your account)</p>
-		</div>
-	</div>
-	<div class="form-group row">
-		<div class="col-md-3">
-			<label for="">Email Address</label>
-		</div>
-		<div class="col-md-9">
-			<input type="email" name="reg_email" size="35" value="[%nohtml%][%FORM id:'reg_email'%][%END FORM%][%end nohtml%]" class="form-control" required>
-			<p class="text-muted small">(order receipts &amp; invoices will be sent here)</p>
-		</div>
-	</div>
-	<div class="form-group row">
-		<div class="col-md-3">
-			<label for="">Password</label>
-		</div>
-		<div class="col-md-9">
-			<input type="password"  name="reg_password" size="20" maxlength="20" value="[%nohtml%][%end nohtml%]" class="form-control" autocomplete="off" required>
-		</div>
-	</div>
-	<div class="form-group row">
-		<div class="col-md-3">
-			<label for="">Confirm Password</label>
-		</div>
-		<div class="col-md-9">
-			<input type="password"  name="reg_password2" size="20" maxlength="20" value="[%nohtml%][%end nohtml%]" class="form-control" autocomplete="off" required>
-		</div>
-	</div>
-</div>
-<div class="">
-	<h3>Company Information</h3>
-	<div class="form-group row">
-		<div class="col-md-3">
-			<label for="">First Name</label>
-		</div>
-		<div class="col-md-9">
-			<input type="text" name="reg_bill_first_name" size="50" value="[%nohtml%][%FORM id:'reg_bill_first_name'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
-		</div>
-	</div>
-	<div class="form-group row">
-		<div class="col-md-3">
-			<label for="">Last Name</label>
-		</div>
-		<div class="col-md-9">
-			<input type="text" name="reg_bill_last_name" size="50" value="[%nohtml%][%FORM id:'reg_bill_last_name'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
-		</div>
-	</div>
-	<div class="form-group row">
-		<div class="col-md-3">
-			<label for="">Company Name</label>
-		</div>
-		<div class="col-md-9">
-			<input type="text" name="reg_bill_company" size="50" value="[%nohtml%][%FORM id:'reg_bill_company'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
-		</div>
-	</div>
-	<div class="form-group row">
-		<div class="col-md-3">
-			<label for="">Address</label>
-		</div>
-		<div class="col-md-9">
-			<input type="text" name="reg_bill_street1" size="50" value="[%nohtml%][%FORM id:'reg_bill_street1'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
-		</div>
-	</div>
-	<div class="form-group row">
-		<div class="col-md-9 offset-md-3">
-			<input type="text" name="reg_bill_street2" size="50" value="[%nohtml%][%FORM id:'reg_bill_street2'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control">
-		</div>
-	</div>
-	<div class="form-group row">
-		<div class="col-md-3">
-			<label for="">Post Code</label>
-		</div>
-		<div class="col-md-3">
-			<input type="text" name="reg_bill_zip" value="[%nohtml%][%FORM id:'reg_bill_zip'%][%END FORM%][%end nohtml%]" size="50" maxlength="10" class="form-control" required>
-		</div>
-	</div>
-	<div class="form-group row">
-		<div class="col-md-3">
-			<label for="">Suburb</label>
-		</div>
-		<div class="col-md-9">
-			<input type="text" name="reg_bill_city" size="50" value="[%nohtml%][%FORM id:'reg_bill_city'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
-		</div>
-	</div>
-	<div class="form-group row">
-		<div class="col-md-3">
-			<label for="">State</label>
-		</div>
-		<div class="col-md-9">
-			<input type="text" name="reg_bill_state" value="[%nohtml%][%FORM id:'reg_bill_state'%][%END FORM%][%end nohtml%]" size="50" maxlength="50" class="form-control" required>
-		</div>
-	</div>
-	<div class="form-group row">
-		<div class="col-md-3">
-			<label for="">Country</label>
-		</div>
-		<div class="col-md-9">
-			<select name="reg_bill_country" class="form-control" required>
-				[%countries sortby:'sortorder,name' %]
-					[%PARAM *body%]
-						<option value="[@country_code@]" [%FORM id:'reg_bill_country' if:'eq' value:'[@country_code@]'%]selected[%END FORM%]>[@country_name@]</option>
-					[%END PARAM%]
-				[%END countries%]
-			</select>
-		</div>
-	</div>
-	<div class="form-group row">
-		<div class="col-md-3">
-			<label for="">[%if [@config:PRIMARY_ABN_LABEL@]%][@config:PRIMARY_ABN_LABEL@][%else%]ABN[%/if%] / [%if [@config:PRIMARY_ACN_LABEL@]%][@config:PRIMARY_ACN_LABEL@][%else%]ACN[%/if%]</label>
-			<span class="text-muted small">optional</span>
-		</div>
-		<div class="col-md-9">
-			<input type="text" name="reg_usercustom2" size="50" value="[%nohtml%][%FORM id:'reg_usercustom2'%][%END FORM%][%end nohtml%]" class="form-control">
-		</div>
-	</div>
-	<div class="form-group row">
-		<div class="col-md-3"> <label for="">Web Site URL <span class="text-muted small">optional</span></label> </div>
-		<div class="col-md-9">
-			<input type="text" name="reg_usercustom3" size="50" value="[%nohtml%][%FORM id:'reg_usercustom3'%][%END FORM%][%end nohtml%]" class="form-control">
-		</div>
-	</div>
+	<form name="adduser" id="adduser" method="POST" action="[%url page:'account' type:'wholesaleregister'%][%END url%]" class="form-horizontal">
+		[%SUBMIT_TOKEN%][%END SUBMIT_TOKEN%]
+		<input type="hidden" name="fn" value="proc">
+		<input type="hidden" name="redirect" value="[@redirect@]">
 
-</div>
-<div class="">
-	<h3>Contact Information</h3>
-	<div class="form-group row">
-		<div class="col-md-3">
-			<label for="">Phone Number</label>
+		<h3>Your Future Login Details</h3>
+		<div class="form-group row">
+			<div class="col-md-3">
+				<label for="">Username</label>
+			</div>
+			<div class="col-md-9">
+				<input type="text"  name="reg_username" size="20" maxlength="15" value="[%nohtml%][%FORM id:'reg_username'%][%END FORM%][%end nohtml%]" class="form-control" required>
+				<p class="text-muted small">(used for future access to your account)</p>
+			</div>
 		</div>
-		<div class="col-md-9">
-			<input type="text" name="reg_phone" size="35" value="[%nohtml%][%FORM id:'reg_phone'%][%END FORM%][%end nohtml%]" class="form-control" required>
+		<div class="form-group row">
+			<div class="col-md-3">
+				<label for="">Email Address</label>
+			</div>
+			<div class="col-md-9">
+				<input type="email" name="reg_email" size="35" value="[%nohtml%][%FORM id:'reg_email'%][%END FORM%][%end nohtml%]" class="form-control" required>
+				<p class="text-muted small">(order receipts &amp; invoices will be sent here)</p>
+			</div>
 		</div>
-	</div>
-	<div class="form-group row">
-		<div class="col-md-3">
-			<label for="">Fax Number</label>
-			<span class="text-muted small">optional</span>
+		<div class="form-group row">
+			<div class="col-md-3">
+				<label for="">Password</label>
+			</div>
+			<div class="col-md-9">
+				<input type="password"  name="reg_password" size="20" maxlength="20" value="[%nohtml%][%end nohtml%]" class="form-control" autocomplete="off" required>
+			</div>
 		</div>
-		<div class="col-md-9">
-			<input type="text" name="reg_fax" size="35" value="[%nohtml%][%FORM id:'reg_fax'%][%END FORM%][%end nohtml%]" class="form-control">
+		<div class="form-group row">
+			<div class="col-md-3">
+				<label for="">Confirm Password</label>
+			</div>
+			<div class="col-md-9">
+				<input type="password"  name="reg_password2" size="20" maxlength="20" value="[%nohtml%][%end nohtml%]" class="form-control" autocomplete="off" required>
+			</div>
 		</div>
-	</div>
-</div>
 
-[%extra_customer_fields%]
-	[%param *header%]
-		<div>
-		<h3>Other Details</h3>
-	[%/param%]
-	[%param *integer_option%]
+		<h3>Company Information</h3>
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">[@field_name@]</label>
-				[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
+				<label for="">First Name</label>
 			</div>
 			<div class="col-md-9">
-				<input type="number" name="[@field_id@]" value="[%NOHTML%][@default_value@][%END NOHTML%]" class="form-control" [%if [@required_field@]%]required[%/if%]>
+				<input type="text" name="reg_bill_first_name" size="50" value="[%nohtml%][%FORM id:'reg_bill_first_name'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
 			</div>
 		</div>
-	[%/param%]
-	[%param *text_option%]
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">[@field_name@]</label>
-				[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
+				<label for="">Last Name</label>
 			</div>
 			<div class="col-md-9">
-				<textarea name="[@field_id@]" class="form-control" cols="20" [%if [@required_field@]%]required[%/if%]>[%NOHTML%][@field_default@][%END NOHTML%]</textarea>
+				<input type="text" name="reg_bill_last_name" size="50" value="[%nohtml%][%FORM id:'reg_bill_last_name'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
 			</div>
 		</div>
-	[%/param%]
-	[%param *short_text_option%]
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">[@field_name@]</label>
-				[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
+				<label for="">Company Name</label>
 			</div>
 			<div class="col-md-9">
-				<input type="text" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" class="form-control" [%if [@required_field@]%]required[%/if%]>
+				<input type="text" name="reg_bill_company" size="50" value="[%nohtml%][%FORM id:'reg_bill_company'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
 			</div>
 		</div>
-	[%/param%]
-	[%param *descimal_option%]
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">[@field_name@]</label>
-				[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
+				<label for="">Address</label>
 			</div>
 			<div class="col-md-9">
-				<input type="number" name="[@field_id@]" value="[%NOHTML%][@default_value@][%END NOHTML%]" class="form-control" [%if [@required_field@]%]required[%/if%]>
+				<input type="text" name="reg_bill_street1" size="50" value="[%nohtml%][%FORM id:'reg_bill_street1'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
 			</div>
 		</div>
-	[%/param%]
-	[%param *boolean_option%]
-		[%site_value id:'register_checkboxes'%]
-			<label class="d-block">
-				<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
-				[@field_name@]
-				[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]					
-			</label> </div>
-		[%/site_value%]
-	[%/param%]
-	[%param *date_option%]
 		<div class="form-group row">
-			<div class="col-md-3">
-				<label for="">[@field_name@]</label>
-				[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
-			</div>
-			<div class="col-md-9">
-				<input class="datepicker form-control" name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required[%/if%]>
+			<div class="col-md-9 offset-md-3">
+				<input type="text" name="reg_bill_street2" size="50" value="[%nohtml%][%FORM id:'reg_bill_street2'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control">
 			</div>
 		</div>
-	[%/param%]
-	[%param *selection_header%]
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">[@field_name@]</label>
-				[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
+				<label for="">Post Code</label>
+			</div>
+			<div class="col-md-3">
+				<input type="text" name="reg_bill_zip" value="[%nohtml%][%FORM id:'reg_bill_zip'%][%END FORM%][%end nohtml%]" size="50" maxlength="10" class="form-control" required>
+			</div>
+		</div>
+		<div class="form-group row">
+			<div class="col-md-3">
+				<label for="">Suburb</label>
 			</div>
 			<div class="col-md-9">
-				<select class="form-control" name="[@field_id@]" [%if [@required_field@]%]required[%/if%]>
-					[%/param%]
-					[%param *selection_body%]
-						<option value="[@option_value@]">[@option_value@]</option>
-					[%/param%]
-				[%param *selection_footer%]
+				<input type="text" name="reg_bill_city" size="50" value="[%nohtml%][%FORM id:'reg_bill_city'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
+			</div>
+		</div>
+		<div class="form-group row">
+			<div class="col-md-3">
+				<label for="">State</label>
+			</div>
+			<div class="col-md-9">
+				<input type="text" name="reg_bill_state" value="[%nohtml%][%FORM id:'reg_bill_state'%][%END FORM%][%end nohtml%]" size="50" maxlength="50" class="form-control" required>
+			</div>
+		</div>
+		<div class="form-group row">
+			<div class="col-md-3">
+				<label for="">Country</label>
+			</div>
+			<div class="col-md-9">
+				<select name="reg_bill_country" class="form-control" required>
+					[%countries sortby:'sortorder,name' %]
+						[%PARAM *body%]
+							<option value="[@country_code@]" [%FORM id:'reg_bill_country' if:'eq' value:'[@country_code@]'%]selected[%END FORM%]>[@country_name@]</option>
+						[%END PARAM%]
+					[%END countries%]
 				</select>
 			</div>
 		</div>
-	[%/param%]
-	[%param *footer%]
+		<div class="form-group row">
+			<div class="col-md-3">
+				<label for="">[%if [@config:PRIMARY_ABN_LABEL@]%][@config:PRIMARY_ABN_LABEL@][%else%]ABN[%/if%] / [%if [@config:PRIMARY_ACN_LABEL@]%][@config:PRIMARY_ACN_LABEL@][%else%]ACN[%/if%]</label>
+				<span class="text-muted small">optional</span>
+			</div>
+			<div class="col-md-9">
+				<input type="text" name="reg_usercustom2" size="50" value="[%nohtml%][%FORM id:'reg_usercustom2'%][%END FORM%][%end nohtml%]" class="form-control">
+			</div>
 		</div>
-	[%/param%]
-[%/extra_customer_fields%]
+		<div class="form-group row">
+			<div class="col-md-3"> <label for="">Web Site URL <span class="text-muted small">optional</span></label> </div>
+			<div class="col-md-9">
+				<input type="text" name="reg_usercustom3" size="50" value="[%nohtml%][%FORM id:'reg_usercustom3'%][%END FORM%][%end nohtml%]" class="form-control">
+			</div>
+		</div>
 
-<div class="form-group">
-	<h3>&nbsp;Terms &amp; Conditions Of Trade</h3>
-	<div style="width:100%; border:1px solid #CCCCCC; height: 150px; overflow:scroll; text-align:left; padding:10px;">
-		[%content_zone id:'wholesale_terms'%][%end content_zone%]
-	</div>
-</div>
+		<h3>Contact Information</h3>
+		<div class="form-group row">
+			<div class="col-md-3">
+				<label for="">Phone Number</label>
+			</div>
+			<div class="col-md-9">
+				<input type="text" name="reg_phone" size="35" value="[%nohtml%][%FORM id:'reg_phone'%][%END FORM%][%end nohtml%]" class="form-control" required>
+			</div>
+		</div>
+		<div class="form-group row">
+			<div class="col-md-3">
+				<label for="">Fax Number</label>
+				<span class="text-muted small">optional</span>
+			</div>
+			<div class="col-md-9">
+				<input type="text" name="reg_fax" size="35" value="[%nohtml%][%FORM id:'reg_fax'%][%END FORM%][%end nohtml%]" class="form-control">
+			</div>
+		</div>
 
-<div class="form-group">
-	[%site_value id:'register_checkboxes' type:'load'/%]
-	<label class="d-block">
-		<input type="checkbox" name="regoptin" value="Y" [%FORM id:'regoptin' if:'eq' value:'Y'%]checked[%END FORM%]> 
-		Subscribe to the [@config:company_name@] newsletter
-		<span class="text-muted small">optional</span>
-	</label>
-	<label class="d-block">
-		<input type="checkbox" name="agree" value="y" required>
-		I agree to the [@config:company_name@] Terms &amp; Conditions Of Trade
-	</label>
-</div>
-	
-	<input type="submit" class="btn btn-lg btn-primary" value="Register">
-</form>
+		[%extra_customer_fields%]
+			[%param *header%]
+				<div>
+				<h3>Other Details</h3>
+			[%/param%]
+			[%param *integer_option%]
+				<div class="form-group row">
+					<div class="col-md-3">
+						<label for="">[@field_name@]</label>
+						[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
+					</div>
+					<div class="col-md-9">
+						<input type="number" name="[@field_id@]" value="[%NOHTML%][@default_value@][%END NOHTML%]" class="form-control" [%if [@required_field@]%]required[%/if%]>
+					</div>
+				</div>
+			[%/param%]
+			[%param *text_option%]
+				<div class="form-group row">
+					<div class="col-md-3">
+						<label for="">[@field_name@]</label>
+						[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
+					</div>
+					<div class="col-md-9">
+						<textarea name="[@field_id@]" class="form-control" cols="20" [%if [@required_field@]%]required[%/if%]>[%NOHTML%][@field_default@][%END NOHTML%]</textarea>
+					</div>
+				</div>
+			[%/param%]
+			[%param *short_text_option%]
+				<div class="form-group row">
+					<div class="col-md-3">
+						<label for="">[@field_name@]</label>
+						[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
+					</div>
+					<div class="col-md-9">
+						<input type="text" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" class="form-control" [%if [@required_field@]%]required[%/if%]>
+					</div>
+				</div>
+			[%/param%]
+			[%param *descimal_option%]
+				<div class="form-group row">
+					<div class="col-md-3">
+						<label for="">[@field_name@]</label>
+						[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
+					</div>
+					<div class="col-md-9">
+						<input type="number" name="[@field_id@]" value="[%NOHTML%][@default_value@][%END NOHTML%]" class="form-control" [%if [@required_field@]%]required[%/if%]>
+					</div>
+				</div>
+			[%/param%]
+			[%param *boolean_option%]
+				[%site_value id:'register_checkboxes'%]
+					<label class="d-block">
+						<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
+						[@field_name@]
+						[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]					
+					</label>
+				[%/site_value%]
+			[%/param%]
+			[%param *date_option%]
+				<div class="form-group row">
+					<div class="col-md-3">
+						<label for="">[@field_name@]</label>
+						[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
+					</div>
+					<div class="col-md-9">
+						<input class="datepicker form-control" name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required[%/if%]>
+					</div>
+				</div>
+			[%/param%]
+			[%param *selection_header%]
+				<div class="form-group row">
+					<div class="col-md-3">
+						<label for="">[@field_name@]</label>
+						[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
+					</div>
+					<div class="col-md-9">
+						<select class="form-control" name="[@field_id@]" [%if [@required_field@]%]required[%/if%]>
+							[%/param%]
+							[%param *selection_body%]
+								<option value="[@option_value@]">[@option_value@]</option>
+							[%/param%]
+						[%param *selection_footer%]
+						</select>
+					</div>
+				</div>
+			[%/param%]
+			[%param *footer%]
+				</div>
+			[%/param%]
+		[%/extra_customer_fields%]
+
+		<div class="form-group">
+			<h3>&nbsp;Terms &amp; Conditions Of Trade</h3>
+			<div style="width:100%; border:1px solid #CCCCCC; height: 150px; overflow:scroll; text-align:left; padding:10px;">
+				[%content_zone id:'wholesale_terms'%][%end content_zone%]
+			</div>
+		</div>
+
+		<div class="form-group">
+			[%site_value id:'register_checkboxes' type:'load'/%]
+			<label class="d-block">
+				<input type="checkbox" name="regoptin" value="Y" [%FORM id:'regoptin' if:'eq' value:'Y'%]checked[%END FORM%]> 
+				Subscribe to the [@config:company_name@] newsletter
+				<span class="text-muted small">optional</span>
+			</label>
+			<label class="d-block">
+				<input type="checkbox" name="agree" value="y" required>
+				I agree to the [@config:company_name@] Terms &amp; Conditions Of Trade
+			</label>
+		</div>
+		
+		<input type="submit" class="btn btn-lg btn-primary" value="Register">
+	</form>
 
 </div>
 [%GA_FUNNEL%]/wholesaleregister/form.html[%END GA_FUNNEL%]

--- a/src/templates/customer/wholesaleregister/template.html
+++ b/src/templates/customer/wholesaleregister/template.html
@@ -18,70 +18,70 @@
 		<h3 class="my-4">Your Future Login Details</h3>
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">Username</label>
+				<label for="reg_username">Username</label>
 			</div>
 			<div class="col-md-9">
-				<input type="text"  name="reg_username" size="20" maxlength="15" value="[%nohtml%][%FORM id:'reg_username'%][%END FORM%][%end nohtml%]" class="form-control" required>
+				<input type="text" name="reg_username" id="reg_username" size="20" maxlength="15" value="[%nohtml%][%FORM id:'reg_username'%][%END FORM%][%end nohtml%]" class="form-control" required>
 				<span class="text-muted small">(used for future access to your account)</span>
 			</div>
 		</div>
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">Email Address</label>
+				<label for="reg_email">Email Address</label>
 			</div>
 			<div class="col-md-9">
-				<input type="email" name="reg_email" size="35" value="[%nohtml%][%FORM id:'reg_email'%][%END FORM%][%end nohtml%]" class="form-control" required>
+				<input type="email" name="reg_email" id="reg_email" size="35" value="[%nohtml%][%FORM id:'reg_email'%][%END FORM%][%end nohtml%]" class="form-control" required>
 				<span class="text-muted small">(order receipts &amp; invoices will be sent here)</span>
 			</div>
 		</div>
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">Password</label>
+				<label for="reg_password">Password</label>
 			</div>
 			<div class="col-md-9">
-				<input type="password"  name="reg_password" size="20" maxlength="20" value="[%nohtml%][%end nohtml%]" class="form-control" autocomplete="off" required>
+				<input type="password" name="reg_password" id="reg_password" size="20" maxlength="20" value="[%nohtml%][%end nohtml%]" class="form-control" autocomplete="off" required>
 			</div>
 		</div>
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">Confirm Password</label>
+				<label for="reg_password2">Confirm Password</label>
 			</div>
 			<div class="col-md-9">
-				<input type="password"  name="reg_password2" size="20" maxlength="20" value="[%nohtml%][%end nohtml%]" class="form-control" autocomplete="off" required>
+				<input type="password" name="reg_password2" id="reg_password2" size="20" maxlength="20" value="[%nohtml%][%end nohtml%]" class="form-control" autocomplete="off" required>
 			</div>
 		</div>
 
 		<h3 class="my-4">Company Information</h3>
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">First Name</label>
+				<label for="reg_bill_first_name">First Name</label>
 			</div>
 			<div class="col-md-9">
-				<input type="text" name="reg_bill_first_name" size="50" value="[%nohtml%][%FORM id:'reg_bill_first_name'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
+				<input type="text" name="reg_bill_first_name" id="reg_bill_first_name" size="50" value="[%nohtml%][%FORM id:'reg_bill_first_name'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
 			</div>
 		</div>
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">Last Name</label>
+				<label for="reg_bill_last_name">Last Name</label>
 			</div>
 			<div class="col-md-9">
-				<input type="text" name="reg_bill_last_name" size="50" value="[%nohtml%][%FORM id:'reg_bill_last_name'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
+				<input type="text" name="reg_bill_last_name" id="reg_bill_last_name" size="50" value="[%nohtml%][%FORM id:'reg_bill_last_name'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
 			</div>
 		</div>
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">Company Name</label>
+				<label for="reg_bill_company">Company Name</label>
 			</div>
 			<div class="col-md-9">
-				<input type="text" name="reg_bill_company" size="50" value="[%nohtml%][%FORM id:'reg_bill_company'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
+				<input type="text" name="reg_bill_company" id="reg_bill_company" size="50" value="[%nohtml%][%FORM id:'reg_bill_company'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
 			</div>
 		</div>
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">Address</label>
+				<label for="reg_bill_street1">Address</label>
 			</div>
 			<div class="col-md-9">
-				<input type="text" name="reg_bill_street1" size="50" value="[%nohtml%][%FORM id:'reg_bill_street1'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
+				<input type="text" name="reg_bill_street1" id="reg_bill_street1" size="50" value="[%nohtml%][%FORM id:'reg_bill_street1'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
 			</div>
 		</div>
 		<div class="form-group row">
@@ -91,34 +91,34 @@
 		</div>
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">Post Code</label>
+				<label for="reg_bill_zip">Post Code</label>
 			</div>
 			<div class="col-md-3">
-				<input type="text" name="reg_bill_zip" value="[%nohtml%][%FORM id:'reg_bill_zip'%][%END FORM%][%end nohtml%]" size="50" maxlength="10" class="form-control" required>
+				<input type="text" name="reg_bill_zip" id="reg_bill_zip" value="[%nohtml%][%FORM id:'reg_bill_zip'%][%END FORM%][%end nohtml%]" size="50" maxlength="10" class="form-control" required>
 			</div>
 		</div>
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">Suburb</label>
+				<label for="reg_bill_city">Suburb</label>
 			</div>
 			<div class="col-md-9">
-				<input type="text" name="reg_bill_city" size="50" value="[%nohtml%][%FORM id:'reg_bill_city'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
+				<input type="text" name="reg_bill_city" id="reg_bill_city" size="50" value="[%nohtml%][%FORM id:'reg_bill_city'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
 			</div>
 		</div>
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">State</label>
+				<label for="reg_bill_state">State</label>
 			</div>
 			<div class="col-md-9">
-				<input type="text" name="reg_bill_state" value="[%nohtml%][%FORM id:'reg_bill_state'%][%END FORM%][%end nohtml%]" size="50" maxlength="50" class="form-control" required>
+				<input type="text" name="reg_bill_state" id="reg_bill_state" value="[%nohtml%][%FORM id:'reg_bill_state'%][%END FORM%][%end nohtml%]" size="50" maxlength="50" class="form-control" required>
 			</div>
 		</div>
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">Country</label>
+				<label for="reg_bill_country">Country</label>
 			</div>
 			<div class="col-md-9">
-				<select name="reg_bill_country" class="form-control" required>
+				<select name="reg_bill_country" id="reg_bill_country" class="form-control" required>
 					[%countries sortby:'sortorder,name' %]
 						[%PARAM *body%]
 							<option value="[@country_code@]" [%FORM id:'reg_bill_country' if:'eq' value:'[@country_code@]'%]selected[%END FORM%]>[@country_name@]</option>
@@ -129,36 +129,39 @@
 		</div>
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">[%if [@config:PRIMARY_ABN_LABEL@]%][@config:PRIMARY_ABN_LABEL@][%else%]ABN[%/if%] / [%if [@config:PRIMARY_ACN_LABEL@]%][@config:PRIMARY_ACN_LABEL@][%else%]ACN[%/if%]</label>
+				<label for="reg_usercustom2">[%if [@config:PRIMARY_ABN_LABEL@]%][@config:PRIMARY_ABN_LABEL@][%else%]ABN[%/if%] / [%if [@config:PRIMARY_ACN_LABEL@]%][@config:PRIMARY_ACN_LABEL@][%else%]ACN[%/if%]</label>
 				<span class="text-muted small">optional</span>
 			</div>
 			<div class="col-md-9">
-				<input type="text" name="reg_usercustom2" size="50" value="[%nohtml%][%FORM id:'reg_usercustom2'%][%END FORM%][%end nohtml%]" class="form-control">
+				<input type="text" name="reg_usercustom2" id="reg_usercustom2" size="50" value="[%nohtml%][%FORM id:'reg_usercustom2'%][%END FORM%][%end nohtml%]" class="form-control">
 			</div>
 		</div>
 		<div class="form-group row">
-			<div class="col-md-3"> <label for="">Web Site URL <span class="text-muted small">optional</span></label> </div>
+			<div class="col-md-3">
+				<label for="reg_usercustom3">Web Site URL</label>
+				<span class="text-muted small">optional</span>				
+			</div>
 			<div class="col-md-9">
-				<input type="text" name="reg_usercustom3" size="50" value="[%nohtml%][%FORM id:'reg_usercustom3'%][%END FORM%][%end nohtml%]" class="form-control">
+				<input type="text" name="reg_usercustom3" id="reg_usercustom3" size="50" value="[%nohtml%][%FORM id:'reg_usercustom3'%][%END FORM%][%end nohtml%]" class="form-control">
 			</div>
 		</div>
 
 		<h3 class="my-4">Contact Information</h3>
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">Phone Number</label>
+				<label for="reg_phone">Phone Number</label>
 			</div>
 			<div class="col-md-9">
-				<input type="text" name="reg_phone" size="35" value="[%nohtml%][%FORM id:'reg_phone'%][%END FORM%][%end nohtml%]" class="form-control" required>
+				<input type="text" name="reg_phone" id="reg_phone" size="35" value="[%nohtml%][%FORM id:'reg_phone'%][%END FORM%][%end nohtml%]" class="form-control" required>
 			</div>
 		</div>
 		<div class="form-group row">
 			<div class="col-md-3">
-				<label for="">Fax Number</label>
+				<label for="reg_fax">Fax Number</label>
 				<span class="text-muted small">optional</span>
 			</div>
 			<div class="col-md-9">
-				<input type="text" name="reg_fax" size="35" value="[%nohtml%][%FORM id:'reg_fax'%][%END FORM%][%end nohtml%]" class="form-control">
+				<input type="text" name="reg_fax" id="reg_fax" size="35" value="[%nohtml%][%FORM id:'reg_fax'%][%END FORM%][%end nohtml%]" class="form-control">
 			</div>
 		</div>
 
@@ -169,51 +172,51 @@
 			[%param *integer_option%]
 				<div class="form-group row">
 					<div class="col-md-3">
-						<label for="">[@field_name@]</label>
+						<label for="[@field_id@]">[@field_name@]</label>
 						[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
 					</div>
 					<div class="col-md-9">
-						<input type="number" name="[@field_id@]" value="[%NOHTML%][@default_value@][%END NOHTML%]" class="form-control" [%if [@required_field@]%]required[%/if%]>
+						<input type="number" name="[@field_id@]" id="[@field_id@]" value="[%NOHTML%][@default_value@][%END NOHTML%]" class="form-control" [%if [@required_field@]%]required[%/if%]>
 					</div>
 				</div>
 			[%/param%]
 			[%param *text_option%]
 				<div class="form-group row">
 					<div class="col-md-3">
-						<label for="">[@field_name@]</label>
+						<label for="[@field_id@]">[@field_name@]</label>
 						[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
 					</div>
 					<div class="col-md-9">
-						<textarea name="[@field_id@]" class="form-control" cols="20" [%if [@required_field@]%]required[%/if%]>[%NOHTML%][@field_default@][%END NOHTML%]</textarea>
+						<textarea name="[@field_id@]" id="[@field_id@]" class="form-control" cols="20" [%if [@required_field@]%]required[%/if%]>[%NOHTML%][@field_default@][%END NOHTML%]</textarea>
 					</div>
 				</div>
 			[%/param%]
 			[%param *short_text_option%]
 				<div class="form-group row">
 					<div class="col-md-3">
-						<label for="">[@field_name@]</label>
+						<label for="[@field_id@]">[@field_name@]</label>
 						[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
 					</div>
 					<div class="col-md-9">
-						<input type="text" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" class="form-control" [%if [@required_field@]%]required[%/if%]>
+						<input type="text" name="[@field_id@]" id="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" class="form-control" [%if [@required_field@]%]required[%/if%]>
 					</div>
 				</div>
 			[%/param%]
 			[%param *descimal_option%]
 				<div class="form-group row">
 					<div class="col-md-3">
-						<label for="">[@field_name@]</label>
+						<label for="[@field_id@]">[@field_name@]</label>
 						[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
 					</div>
 					<div class="col-md-9">
-						<input type="number" name="[@field_id@]" value="[%NOHTML%][@default_value@][%END NOHTML%]" class="form-control" [%if [@required_field@]%]required[%/if%]>
+						<input type="number" name="[@field_id@]" id="[@field_id@]" value="[%NOHTML%][@default_value@][%END NOHTML%]" class="form-control" [%if [@required_field@]%]required[%/if%]>
 					</div>
 				</div>
 			[%/param%]
 			[%param *boolean_option%]
 				[%site_value id:'register_checkboxes'%]
 					<label class="d-block">
-						<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
+						<input type="checkbox" name="[@field_id@]" id="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
 						[@field_name@]
 						[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]					
 					</label>
@@ -222,7 +225,7 @@
 			[%param *date_option%]
 				<div class="form-group row">
 					<div class="col-md-3">
-						<label for="">[@field_name@]</label>
+						<label for="[@field_id@]">[@field_name@]</label>
 						[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
 					</div>
 					<div class="col-md-9">
@@ -233,11 +236,11 @@
 			[%param *selection_header%]
 				<div class="form-group row">
 					<div class="col-md-3">
-						<label for="">[@field_name@]</label>
+						<label for="[@field_id@]">[@field_name@]</label>
 						[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
 					</div>
 					<div class="col-md-9">
-						<select class="form-control" name="[@field_id@]" [%if [@required_field@]%]required[%/if%]>
+						<select class="form-control" name="[@field_id@]" id="[@field_id@]" [%if [@required_field@]%]required[%/if%]>
 							[%/param%]
 							[%param *selection_body%]
 								<option value="[@option_value@]">[@option_value@]</option>

--- a/src/templates/customer/wholesaleregister/template.html
+++ b/src/templates/customer/wholesaleregister/template.html
@@ -184,15 +184,15 @@
 		</div>
 	[%/param%]
 	[%param *boolean_option%]
-		<div class="form-group row">
-			<label class="control-label col-md-3">
-				[@field_name@]
-				[%if [@required_field@]%]<span style="color:red;">*</span>[%/if%]
-			</label>
-			<div class="col-md-9">
-				<input type="checkbox" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] class="form-control" [%if [@required_field@]%]required[%/if%]>
+		[%site_value id:'register_checkboxes'%]
+			<div class="checkbox">
+				<label>
+					<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
+					[@field_name@]
+				</label>
+				[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
 			</div>
-		</div>
+		[%/site_value%]
 	[%/param%]
 	[%param *date_option%]
 		<div class="form-group row">
@@ -227,18 +227,25 @@
 	[%/param%]
 [%/extra_customer_fields%]
 
-<div class="">
+<div>
 	<h3>&nbsp;Terms &amp; Conditions Of Trade</h3>
 	<div style="width:100%; border:1px solid #CCCCCC; height: 150px; overflow:scroll; text-align:left; padding:10px;">
 		[%content_zone id:'wholesale_terms'%][%end content_zone%]
 	</div>
-	<p>
-		<input type="checkbox" name="regoptin" value="Y" [%FORM id:'regoptin' if:'eq' value:'Y'%]checked[%END FORM%]>  Subscribe to the [@config:company_name@] newsletter.
-	</p>
-	<p>
-		<input type="checkbox" name="agree" value="y" required>
-		I agree to the [@config:company_name@] terms of trade.
-	</p>
+
+	[%site_value id:'register_checkboxes' type:'load'/%]
+	<div>
+		<label>
+			<input type="checkbox" name="regoptin" value="Y" [%FORM id:'regoptin' if:'eq' value:'Y'%]checked[%END FORM%]> 
+			Subscribe to the [@config:company_name@] newsletter.
+		</label>
+	</div>
+	<div>
+		<label>
+			<input type="checkbox" name="agree" value="y" required>
+			I agree to the [@config:company_name@] terms of trade.
+		</label>
+	</div>
 </div>
 	<input type="submit" class="btn btn-lg btn-primary" value="Register">
 </form>

--- a/src/templates/customer/wholesaleregister/template.html
+++ b/src/templates/customer/wholesaleregister/template.html
@@ -185,13 +185,11 @@
 	[%/param%]
 	[%param *boolean_option%]
 		[%site_value id:'register_checkboxes'%]
-			<div class="checkbox">
-				<label>
-					<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
-					[@field_name@]
-				</label>
-				[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]
-			</div>
+			<label class="d-block">
+				<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
+				[@field_name@]
+				[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]					
+			</label>
 		[%/site_value%]
 	[%/param%]
 	[%param *date_option%]
@@ -234,19 +232,17 @@
 	</div>
 
 	[%site_value id:'register_checkboxes' type:'load'/%]
-	<div>
-		<label>
-			<input type="checkbox" name="regoptin" value="Y" [%FORM id:'regoptin' if:'eq' value:'Y'%]checked[%END FORM%]> 
-			Subscribe to the [@config:company_name@] newsletter.
-		</label>
-	</div>
-	<div>
-		<label>
-			<input type="checkbox" name="agree" value="y" required>
-			I agree to the [@config:company_name@] terms of trade.
-		</label>
-	</div>
+	<label class="d-block">
+		<input type="checkbox" name="regoptin" value="Y" [%FORM id:'regoptin' if:'eq' value:'Y'%]checked[%END FORM%]> 
+		Subscribe to the [@config:company_name@] newsletter
+		<span class="text-muted small">optional</span>
+	</label>
+	<label class="d-block">
+		<input type="checkbox" name="agree" value="y" required>
+		I agree to the [@config:company_name@] terms of trade.
+	</label>
 </div>
+
 	<input type="submit" class="btn btn-lg btn-primary" value="Register">
 </form>
 

--- a/src/templates/customer/wholesaleregister/template.html
+++ b/src/templates/customer/wholesaleregister/template.html
@@ -230,7 +230,9 @@
 	<div style="width:100%; border:1px solid #CCCCCC; height: 150px; overflow:scroll; text-align:left; padding:10px;">
 		[%content_zone id:'wholesale_terms'%][%end content_zone%]
 	</div>
+</div>
 
+<div class="form-group">
 	[%site_value id:'register_checkboxes' type:'load'/%]
 	<label class="d-block">
 		<input type="checkbox" name="regoptin" value="Y" [%FORM id:'regoptin' if:'eq' value:'Y'%]checked[%END FORM%]> 
@@ -239,10 +241,10 @@
 	</label>
 	<label class="d-block">
 		<input type="checkbox" name="agree" value="y" required>
-		I agree to the [@config:company_name@] terms of trade.
+		I agree to the [@config:company_name@] Terms &amp; Conditions Of Trade
 	</label>
 </div>
-
+	
 	<input type="submit" class="btn btn-lg btn-primary" value="Register">
 </form>
 

--- a/src/templates/customer/wholesaleregister/template.html
+++ b/src/templates/customer/wholesaleregister/template.html
@@ -15,14 +15,14 @@
 		<input type="hidden" name="fn" value="proc">
 		<input type="hidden" name="redirect" value="[@redirect@]">
 
-		<h3>Your Future Login Details</h3>
+		<h3 class="my-4">Your Future Login Details</h3>
 		<div class="form-group row">
 			<div class="col-md-3">
 				<label for="">Username</label>
 			</div>
 			<div class="col-md-9">
 				<input type="text"  name="reg_username" size="20" maxlength="15" value="[%nohtml%][%FORM id:'reg_username'%][%END FORM%][%end nohtml%]" class="form-control" required>
-				<p class="text-muted small">(used for future access to your account)</p>
+				<span class="text-muted small">(used for future access to your account)</span>
 			</div>
 		</div>
 		<div class="form-group row">
@@ -31,7 +31,7 @@
 			</div>
 			<div class="col-md-9">
 				<input type="email" name="reg_email" size="35" value="[%nohtml%][%FORM id:'reg_email'%][%END FORM%][%end nohtml%]" class="form-control" required>
-				<p class="text-muted small">(order receipts &amp; invoices will be sent here)</p>
+				<span class="text-muted small">(order receipts &amp; invoices will be sent here)</span>
 			</div>
 		</div>
 		<div class="form-group row">
@@ -51,7 +51,7 @@
 			</div>
 		</div>
 
-		<h3>Company Information</h3>
+		<h3 class="my-4">Company Information</h3>
 		<div class="form-group row">
 			<div class="col-md-3">
 				<label for="">First Name</label>
@@ -143,7 +143,7 @@
 			</div>
 		</div>
 
-		<h3>Contact Information</h3>
+		<h3 class="my-4">Contact Information</h3>
 		<div class="form-group row">
 			<div class="col-md-3">
 				<label for="">Phone Number</label>
@@ -164,8 +164,7 @@
 
 		[%extra_customer_fields%]
 			[%param *header%]
-				<div>
-				<h3>Other Details</h3>
+				<h3 class="my-4">Other Details</h3>
 			[%/param%]
 			[%param *integer_option%]
 				<div class="form-group row">
@@ -248,13 +247,10 @@
 					</div>
 				</div>
 			[%/param%]
-			[%param *footer%]
-				</div>
-			[%/param%]
 		[%/extra_customer_fields%]
 
 		<div class="form-group">
-			<h3>&nbsp;Terms &amp; Conditions Of Trade</h3>
+			<h3 class="my-4">Terms &amp; Conditions Of Trade</h3>
 			<div style="width:100%; border:1px solid #CCCCCC; height: 150px; overflow:scroll; text-align:left; padding:10px;">
 				[%content_zone id:'wholesale_terms'%][%end content_zone%]
 			</div>

--- a/src/templates/customer/wholesaleregister/template.html
+++ b/src/templates/customer/wholesaleregister/template.html
@@ -86,14 +86,15 @@
 		</div>
 		<div class="form-group row">
 			<div class="col-md-9 offset-md-3">
-				<input type="text" name="reg_bill_street2" size="50" value="[%nohtml%][%FORM id:'reg_bill_street2'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control">
+				<label for="reg_bill_street2" class="sr-only">Address line 2</label>
+				<input type="text" name="reg_bill_street2" id="reg_bill_street2" size="50" value="[%nohtml%][%FORM id:'reg_bill_street2'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control">
 			</div>
 		</div>
 		<div class="form-group row">
 			<div class="col-md-3">
 				<label for="reg_bill_zip">Post Code</label>
 			</div>
-			<div class="col-md-3">
+			<div class="col-md-9">
 				<input type="text" name="reg_bill_zip" id="reg_bill_zip" value="[%nohtml%][%FORM id:'reg_bill_zip'%][%END FORM%][%end nohtml%]" size="50" maxlength="10" class="form-control" required>
 			</div>
 		</div>

--- a/src/templates/customer/wholesaleregister/template.html
+++ b/src/templates/customer/wholesaleregister/template.html
@@ -17,27 +17,35 @@
 <div class="">
 	<h3>Your Future Login Details</h3>
 	<div class="form-group row">
-		<label class="control-label col-md-3">Username<span style="color:red;">*</span></label>
+		<div class="col-md-3">
+			<label for="">Username</label>
+		</div>
 		<div class="col-md-9">
 			<input type="text"  name="reg_username" size="20" maxlength="15" value="[%nohtml%][%FORM id:'reg_username'%][%END FORM%][%end nohtml%]" class="form-control" required>
 			<p class="text-muted small">(used for future access to your account)</p>
 		</div>
 	</div>
 	<div class="form-group row">
-		<label class="control-label col-md-3">Email Address<span style="color:red;">*</span></label>
+		<div class="col-md-3">
+			<label for="">Email Address</label>
+		</div>
 		<div class="col-md-9">
 			<input type="email" name="reg_email" size="35" value="[%nohtml%][%FORM id:'reg_email'%][%END FORM%][%end nohtml%]" class="form-control" required>
 			<p class="text-muted small">(order receipts &amp; invoices will be sent here)</p>
 		</div>
 	</div>
 	<div class="form-group row">
-		<label class="control-label col-md-3">Password<span style="color:red;">*</span></label>
+		<div class="col-md-3">
+			<label for="">Password</label>
+		</div>
 		<div class="col-md-9">
 			<input type="password"  name="reg_password" size="20" maxlength="20" value="[%nohtml%][%end nohtml%]" class="form-control" autocomplete="off" required>
 		</div>
 	</div>
 	<div class="form-group row">
-		<label class="control-label col-md-3">Confirm Password<span style="color:red;">*</span></label>
+		<div class="col-md-3">
+			<label for="">Confirm Password</label>
+		</div>
 		<div class="col-md-9">
 			<input type="password"  name="reg_password2" size="20" maxlength="20" value="[%nohtml%][%end nohtml%]" class="form-control" autocomplete="off" required>
 		</div>
@@ -46,25 +54,33 @@
 <div class="">
 	<h3>Company Information</h3>
 	<div class="form-group row">
-		<label class="control-label col-md-3">First Name<span style="color:red;">*</span></label>
+		<div class="col-md-3">
+			<label for="">First Name</label>
+		</div>
 		<div class="col-md-9">
 			<input type="text" name="reg_bill_first_name" size="50" value="[%nohtml%][%FORM id:'reg_bill_first_name'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
 		</div>
 	</div>
 	<div class="form-group row">
-		<label class="control-label col-md-3">Last Name<span style="color:red;">*</span></label>
+		<div class="col-md-3">
+			<label for="">Last Name</label>
+		</div>
 		<div class="col-md-9">
 			<input type="text" name="reg_bill_last_name" size="50" value="[%nohtml%][%FORM id:'reg_bill_last_name'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
 		</div>
 	</div>
 	<div class="form-group row">
-		<label class="control-label col-md-3">Company Name<span style="color:red;">*</span></label>
+		<div class="col-md-3">
+			<label for="">Company Name</label>
+		</div>
 		<div class="col-md-9">
 			<input type="text" name="reg_bill_company" size="50" value="[%nohtml%][%FORM id:'reg_bill_company'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
 		</div>
 	</div>
 	<div class="form-group row">
-		<label class="control-label col-md-3">Address<span style="color:red;">*</span></label>
+		<div class="col-md-3">
+			<label for="">Address</label>
+		</div>
 		<div class="col-md-9">
 			<input type="text" name="reg_bill_street1" size="50" value="[%nohtml%][%FORM id:'reg_bill_street1'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
 		</div>
@@ -75,25 +91,33 @@
 		</div>
 	</div>
 	<div class="form-group row">
-		<label class="control-label col-md-3">Post Code<span style="color:red;">*</span></label>
+		<div class="col-md-3">
+			<label for="">Post Code</label>
+		</div>
 		<div class="col-md-3">
 			<input type="text" name="reg_bill_zip" value="[%nohtml%][%FORM id:'reg_bill_zip'%][%END FORM%][%end nohtml%]" size="50" maxlength="10" class="form-control" required>
 		</div>
 	</div>
 	<div class="form-group row">
-		<label class="control-label col-md-3">Suburb<span style="color:red;">*</span></label>
+		<div class="col-md-3">
+			<label for="">Suburb</label>
+		</div>
 		<div class="col-md-9">
 			<input type="text" name="reg_bill_city" size="50" value="[%nohtml%][%FORM id:'reg_bill_city'%][%END FORM%][%end nohtml%]" maxlength="50" class="form-control" required>
 		</div>
 	</div>
 	<div class="form-group row">
-		<label class="control-label col-md-3">State<span style="color:red;">*</span></label>
+		<div class="col-md-3">
+			<label for="">State</label>
+		</div>
 		<div class="col-md-9">
 			<input type="text" name="reg_bill_state" value="[%nohtml%][%FORM id:'reg_bill_state'%][%END FORM%][%end nohtml%]" size="50" maxlength="50" class="form-control" required>
 		</div>
 	</div>
 	<div class="form-group row">
-		<label class="control-label col-md-3">Country<span style="color:red;">*</span></label>
+		<div class="col-md-3">
+			<label for="">Country</label>
+		</div>
 		<div class="col-md-9">
 			<select name="reg_bill_country" class="form-control" required>
 				[%countries sortby:'sortorder,name' %]
@@ -105,13 +129,16 @@
 		</div>
 	</div>
 	<div class="form-group row">
-		<label class="control-label col-md-3">[%if [@config:PRIMARY_ABN_LABEL@]%][@config:PRIMARY_ABN_LABEL@][%else%]ABN[%/if%] / [%if [@config:PRIMARY_ACN_LABEL@]%][@config:PRIMARY_ACN_LABEL@][%else%]ACN[%/if%]</label>
+		<div class="col-md-3">
+			<label for="">[%if [@config:PRIMARY_ABN_LABEL@]%][@config:PRIMARY_ABN_LABEL@][%else%]ABN[%/if%] / [%if [@config:PRIMARY_ACN_LABEL@]%][@config:PRIMARY_ACN_LABEL@][%else%]ACN[%/if%]</label>
+			<span class="text-muted small">optional</span>
+		</div>
 		<div class="col-md-9">
 			<input type="text" name="reg_usercustom2" size="50" value="[%nohtml%][%FORM id:'reg_usercustom2'%][%END FORM%][%end nohtml%]" class="form-control">
 		</div>
 	</div>
 	<div class="form-group row">
-		<label class="control-label col-md-3">Web Site URL</label>
+		<div class="col-md-3"> <label for="">Web Site URL <span class="text-muted small">optional</span></label> </div>
 		<div class="col-md-9">
 			<input type="text" name="reg_usercustom3" size="50" value="[%nohtml%][%FORM id:'reg_usercustom3'%][%END FORM%][%end nohtml%]" class="form-control">
 		</div>
@@ -121,13 +148,18 @@
 <div class="">
 	<h3>Contact Information</h3>
 	<div class="form-group row">
-		<label class="control-label col-md-3">Phone Number<span style="color:red;">*</span></label>
+		<div class="col-md-3">
+			<label for="">Phone Number</label>
+		</div>
 		<div class="col-md-9">
 			<input type="text" name="reg_phone" size="35" value="[%nohtml%][%FORM id:'reg_phone'%][%END FORM%][%end nohtml%]" class="form-control" required>
 		</div>
 	</div>
 	<div class="form-group row">
-		<label class="control-label col-md-3">Fax Number</label>
+		<div class="col-md-3">
+			<label for="">Fax Number</label>
+			<span class="text-muted small">optional</span>
+		</div>
 		<div class="col-md-9">
 			<input type="text" name="reg_fax" size="35" value="[%nohtml%][%FORM id:'reg_fax'%][%END FORM%][%end nohtml%]" class="form-control">
 		</div>
@@ -141,10 +173,10 @@
 	[%/param%]
 	[%param *integer_option%]
 		<div class="form-group row">
-			<label class="control-label col-md-3">
-				[@field_name@]
-				[%if [@required_field@]%]<span style="color:red;">*</span>[%/if%]
-			</label>
+			<div class="col-md-3">
+				<label for="">[@field_name@]</label>
+				[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
+			</div>
 			<div class="col-md-9">
 				<input type="number" name="[@field_id@]" value="[%NOHTML%][@default_value@][%END NOHTML%]" class="form-control" [%if [@required_field@]%]required[%/if%]>
 			</div>
@@ -152,10 +184,10 @@
 	[%/param%]
 	[%param *text_option%]
 		<div class="form-group row">
-			<label class="control-label col-md-3">
-				[@field_name@]
-				[%if [@required_field@]%]<span style="color:red;">*</span>[%/if%]
-			</label>
+			<div class="col-md-3">
+				<label for="">[@field_name@]</label>
+				[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
+			</div>
 			<div class="col-md-9">
 				<textarea name="[@field_id@]" class="form-control" cols="20" [%if [@required_field@]%]required[%/if%]>[%NOHTML%][@field_default@][%END NOHTML%]</textarea>
 			</div>
@@ -163,10 +195,10 @@
 	[%/param%]
 	[%param *short_text_option%]
 		<div class="form-group row">
-			<label class="control-label col-md-3">
-				[@field_name@]
-				[%if [@required_field@]%]<span style="color:red;">*</span>[%/if%]
-			</label>
+			<div class="col-md-3">
+				<label for="">[@field_name@]</label>
+				[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
+			</div>
 			<div class="col-md-9">
 				<input type="text" name="[@field_id@]" value="[%NOHTML%][@field_default@][%END NOHTML%]" class="form-control" [%if [@required_field@]%]required[%/if%]>
 			</div>
@@ -174,10 +206,10 @@
 	[%/param%]
 	[%param *descimal_option%]
 		<div class="form-group row">
-			<label class="control-label col-md-3">
-				[@field_name@]
-				[%if [@required_field@]%]<span style="color:red;">*</span>[%/if%]
-			</label>
+			<div class="col-md-3">
+				<label for="">[@field_name@]</label>
+				[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
+			</div>
 			<div class="col-md-9">
 				<input type="number" name="[@field_id@]" value="[%NOHTML%][@default_value@][%END NOHTML%]" class="form-control" [%if [@required_field@]%]required[%/if%]>
 			</div>
@@ -189,15 +221,15 @@
 				<input type="checkbox" id="[@field_id@]" name="[@field_id@]" value="y" [%DATA id:'default_value' if:'eq' value:'y'%]checked[%END DATA%] [%if [@required_field@]%]required="true"[%/if%]>
 				[@field_name@]
 				[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]					
-			</label>
+			</label> </div>
 		[%/site_value%]
 	[%/param%]
 	[%param *date_option%]
 		<div class="form-group row">
-			<label class="control-label col-md-3">
-				[@field_name@]
-				[%if [@required_field@]%]<span style="color:red;">*</span>[%/if%]
-			</label>
+			<div class="col-md-3">
+				<label for="">[@field_name@]</label>
+				[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
+			</div>
 			<div class="col-md-9">
 				<input class="datepicker form-control" name="[@field_id@]" id="[@field_id@]" type="text" value="[%NOHTML%][@default_value@][%END NOHTML%]" [%if [@required_field@]%]required[%/if%]>
 			</div>
@@ -205,10 +237,10 @@
 	[%/param%]
 	[%param *selection_header%]
 		<div class="form-group row">
-			<label class="control-label col-md-3">
-				[@field_name@]
-				[%if [@required_field@]%]<span style="color:red;">*</span>[%/if%]
-			</label>
+			<div class="col-md-3">
+				<label for="">[@field_name@]</label>
+				[%if [@required_field@] eq 'n'%]<span class="text-muted small">optional</span>[%/if%]			
+			</div>
 			<div class="col-md-9">
 				<select class="form-control" name="[@field_id@]" [%if [@required_field@]%]required[%/if%]>
 					[%/param%]


### PR DESCRIPTION
## all
- Remove `.form-control` class from checkbox type custom fields and group them all together in the footer of each form
- Use full width `textarea` elements for text type custom fields (as opposed to short_text)

## login/register
- Group text type custom fields together at the bottom of the form
- Fix date custom field display issues

## wholesaleregister
- Swap required labels for optional field labels
- Make postcode input full width - it was the only field that wasn't and looked out of place