### PR TITLE
Preload styles for modern browsers

### DIFF
--- a/src/templates/headers/includes/head.template.html
+++ b/src/templates/headers/includes/head.template.html
@@ -13,10 +13,8 @@
 <link rel="canonical" href="[@config:canonical_url@]" itemprop="url"/>
 <link rel="shortcut icon" href="/assets/favicon_logo.png?[@config:neto_css_version@]"/>
 <!-- Neto Assets -->
-<link href="//cdn.neto.com.au" rel="dns-prefetch">
-<link href="//cdn.neto.com.au" rel="preconnect">
-<link href="//use.fontawesome.com" rel="dns-prefetch">
-<!-- Google Analytics-->
+<link rel="dns-prefetch preconnect" href="//cdn.neto.com.au">
+<link rel="dns-prefetch" href="//use.fontawesome.com">
 <link rel="dns-prefetch" href="//google-analytics.com">
 [%cdn_asset html:'1' type:'css' domain:'use.fontawesome.com/releases' library:'' version:'v5.0.11'%]css/all.css[%/cdn_asset%]
 [%cdn_asset html:'1' type:'css' library:'jquery_ui' version:'1.11.1'%]css/custom-theme/jquery-ui-1.8.18.custom.css[%/cdn_asset%]

--- a/src/templates/headers/includes/head.template.html
+++ b/src/templates/headers/includes/head.template.html
@@ -12,6 +12,12 @@
 <title itemprop='name'>[%url_info name:'page_title'/%]</title>
 <link rel="canonical" href="[@config:canonical_url@]" itemprop="url"/>
 <link rel="shortcut icon" href="/assets/favicon_logo.png?[@config:neto_css_version@]"/>
+<!-- Neto Assets -->
+<link href="//cdn.neto.com.au" rel="dns-prefetch">
+<link href="//cdn.neto.com.au" rel="preconnect">
+<link href="//use.fontawesome.com" rel="dns-prefetch">
+<!-- Google Analytics-->
+<link rel="dns-prefetch" href="//google-analytics.com">
 [%cdn_asset html:'1' type:'css' domain:'use.fontawesome.com/releases' library:'' version:'v5.0.11'%]css/all.css[%/cdn_asset%]
 [%cdn_asset html:'1' type:'css' library:'jquery_ui' version:'1.11.1'%]css/custom-theme/jquery-ui-1.8.18.custom.css[%/cdn_asset%]
 [%cdn_asset html:'1' type:'css' library:'fancybox' version:'2.1.5'%]jquery.fancybox.css[%/cdn_asset%]

--- a/src/templates/headers/template.html
+++ b/src/templates/headers/template.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head itemscope itemtype="http://schema.org/WebSite">
+	<link rel="preload" href="[%ntheme_asset%]css/app.css[%/ntheme_asset%]" as="style">
+	<link rel="preload" href="[%ntheme_asset%]css/style.css[%/ntheme_asset%]" as="style">
 	[%load_template file:'headers/includes/head.template.html'/%]
 	<link class="theme-selector" rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/app.css[%/ntheme_asset%]" media="all"/>
 	<link rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/style.css[%/ntheme_asset%]" media="all"/>

--- a/src/templates/headers/template.html
+++ b/src/templates/headers/template.html
@@ -1,6 +1,35 @@
 <!DOCTYPE html>
 <html lang="en">
 <head itemscope itemtype="http://schema.org/WebSite">
+	<!-- Neto Assets -->
+	<link href="//cdn.neto.com.au" rel="dns-prefetch">
+	<link href="//cdn.neto.com.au" rel="preconnect">
+	<link href="//use.fontawesome.com" rel="dns-prefetch">
+
+	<!-- New Relic -->
+	<link rel="dns-prefetch" href="//beacon-1.newrelic.com">
+	<link rel="dns-prefetch" href="//js-agent.newrelic.com">
+
+	<!-- Google Analytics-->
+	<link rel="dns-prefetch" href="//googletagmanager.com">
+	<link rel="dns-prefetch" href="//google-analytics.com">
+
+	<!-- Facebook Events -->
+	<link rel="dns-prefetch" href="//facebook.com">
+	<link rel="dns-prefetch" href="//bam.nr-data.net">
+
+	<!-- Google Fonts -->
+	<!-- <link rel="dns-prefetch" href="//fonts.gstatic.com"> -->
+
+	<!-- Twitter  -->
+	<!-- <link rel="dns-prefetch" href="//twitter.com"> -->
+	<!-- <link rel="dns-prefetch" href="//platform.twitter.com"> -->
+
+	<!-- Google Ads -->
+	<!-- <link rel="dns-prefetch" href="//googleads.g.doubleclick.net"> -->
+	<!-- <link rel="dns-prefetch" href="//stats.g.doubleclick.net"> -->
+	<!-- <link rel="dns-prefetch" href="//www.googleadservices.com"> -->
+	
 	<link rel="preload" href="[%ntheme_asset%]css/app.css[%/ntheme_asset%]" as="style">
 	<link rel="preload" href="[%ntheme_asset%]css/style.css[%/ntheme_asset%]" as="style">
 	[%load_template file:'headers/includes/head.template.html'/%]

--- a/src/templates/headers/template.html
+++ b/src/templates/headers/template.html
@@ -1,38 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head itemscope itemtype="http://schema.org/WebSite">
-	<!-- Neto Assets -->
-	<link href="//cdn.neto.com.au" rel="dns-prefetch">
-	<link href="//cdn.neto.com.au" rel="preconnect">
-	<link href="//use.fontawesome.com" rel="dns-prefetch">
-
-	<!-- New Relic -->
-	<link rel="dns-prefetch" href="//beacon-1.newrelic.com">
-	<link rel="dns-prefetch" href="//js-agent.newrelic.com">
-
-	<!-- Google Analytics-->
-	<link rel="dns-prefetch" href="//googletagmanager.com">
-	<link rel="dns-prefetch" href="//google-analytics.com">
-
-	<!-- Facebook Events -->
-	<link rel="dns-prefetch" href="//facebook.com">
-	<link rel="dns-prefetch" href="//bam.nr-data.net">
-
-	<!-- Google Fonts -->
-	<!-- <link rel="dns-prefetch" href="//fonts.gstatic.com"> -->
-
-	<!-- Twitter  -->
-	<!-- <link rel="dns-prefetch" href="//twitter.com"> -->
-	<!-- <link rel="dns-prefetch" href="//platform.twitter.com"> -->
-
-	<!-- Google Ads -->
-	<!-- <link rel="dns-prefetch" href="//googleads.g.doubleclick.net"> -->
-	<!-- <link rel="dns-prefetch" href="//stats.g.doubleclick.net"> -->
-	<!-- <link rel="dns-prefetch" href="//www.googleadservices.com"> -->
-	
+	[%load_template file:'headers/includes/head.template.html'/%]
 	<link rel="preload" href="[%ntheme_asset%]css/app.css[%/ntheme_asset%]" as="style">
 	<link rel="preload" href="[%ntheme_asset%]css/style.css[%/ntheme_asset%]" as="style">
-	[%load_template file:'headers/includes/head.template.html'/%]
 	<link class="theme-selector" rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/app.css[%/ntheme_asset%]" media="all"/>
 	<link rel="stylesheet" type="text/css" href="[%ntheme_asset%]css/style.css[%/ntheme_asset%]" media="all"/>
 </head>


### PR DESCRIPTION
Potential solution to #401 

More info
https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content

without preload
<img width="1149" alt="screen shot 2018-05-12 at 12 19 36 am" src="https://user-images.githubusercontent.com/11847839/39929002-4149bf88-557a-11e8-9e70-ccc92d97fc2e.png">

with preload
<img width="1131" alt="screen shot 2018-05-12 at 12 19 11 am" src="https://user-images.githubusercontent.com/11847839/39929003-417f5ee0-557a-11e8-8677-ef351655c074.png">
