### PR TITLE
Min on shipping calculator

### DIFF
--- a/src/templates/products/includes/buying_options.template.html
+++ b/src/templates/products/includes/buying_options.template.html
@@ -143,7 +143,7 @@
 		<div class="panel-body">
 			<div class="row btn-stack">
 				<div class="col-xs-12 col-md-3">
-					<input type="number" name="input" id="n_qty" value="[@qty@]" size="2" class="form-control" placeholder="Qty" aria-label="qty">
+					<input type="number" name="input" min="0" id="n_qty" value="[@qty@]" size="2" class="form-control" placeholder="Qty" aria-label="qty">
 				</div>
 				<div class="col-xs-12 col-md-3">
 					<select id="country" class="form-control" aria-label="Country">


### PR DESCRIPTION
Added from customer feedback about shipping calculator allowing negative number. Will still allow if typed but stops the increment from going below zero on click