### PR TITLE
Simplified product_scripts

### DIFF
--- a/src/templates/products/includes/product_scripts.template.html
+++ b/src/templates/products/includes/product_scripts.template.html
@@ -34,32 +34,27 @@
 			[%/if%]
 		});
 	</script>
-	<script type="text/javascript" src="//cdn.neto.com.au/assets/neto-cdn/zoom/1.4/jquery.zoom-min.js"></script>
+	[%cdn_asset html:'1' type:'js' library:'zoom' version:'1.4'%]jquery.zoom-min.js[%/cdn_asset%]
+	[%cdn_asset html:'1' type:'js' library:'jcountdown' version:'1.4'%]jquery.jcountdown.min.js[%/cdn_asset%]
 	<script type="text/javascript">
 		$(document).ready(function(){
+			// Product image zoom
 			$('.zoom').zoom();
-		});
-	</script>
-	<script type="text/javascript" src="//cdn.neto.com.au/assets/neto-cdn/jcountdown/1.4/jquery.jcountdown.min.js"></script>
-	<script type="text/javascript">
-		$(document).ready(function() {
+			// Sales countdown
 			$("#sale-end").countdown({
 				date: "[%format type:'date' format:'#K #d, #Y  #H:#I'%][@promo_end@][%/format%]"
 			});
-		});
-	</script>
-	<script>
-		$(document).ready(function(){
+			// Tab a11y
 			$("li[role='tab']").click(function(){
 				$("li[role='tab']").attr("aria-selected","false"); //deselect all the tabs
-			 	$(this).attr("aria-selected","true");  // select this tab
+				$(this).attr("aria-selected","true");  // select this tab
 				var tabpanid= $(this).attr("aria-controls"); //find out what tab panel this tab controls
-			   var tabpan = $("#"+tabpanid);
+				var tabpan = $("#"+tabpanid);
 				$("div[role='tabpanel']").attr("aria-hidden","true"); //hide all the panels
 				tabpan.attr("aria-hidden","false");  // show our panel
-			 });
-		})
+			});
+		});
 		$(document).on("click", ".btn-ajax-loads", buttonLoading);
-		$('#_jstl__buying_options').on('click', '.wishlist_toggle', function(e){e.preventDefault();})
+		$('#_jstl__buying_options').on('click', '.wishlist_toggle', function(e){e.preventDefault();});
 	</script>
 [%/site_value%]


### PR DESCRIPTION
zoom and jcountdown should be using base cdn tag instead of being hardcoded.

We do not need 3 script tags for these document.ready functions, instead it should combine into one and also comment on what the functions are trying to achieve.