### PR TITLE
Removed problematic class

### DIFF
--- a/src/js/custom.js
+++ b/src/js/custom.js
@@ -143,10 +143,6 @@ $(".js-social-share").on("click", function(e) {
 	windowPopup($(this).attr("href"), 500, 300);
 });
 
-$('.nToggleMenu').click(function(){
-	var toggleTarget = $(this).attr('data-target')
-	$(toggleTarget).slideToggle();
-});
 var focused = $('body');
 var lastFocused = $('body');
 // Capture the current element the user focused in

--- a/src/templates/headers/template.html
+++ b/src/templates/headers/template.html
@@ -47,7 +47,7 @@
 			<nav class="navbar navbar-default">
 				<div class="navbar-header">
 					<ul class="navigation-list list-inline visible-xs nMobileNav" role="navigation" aria-label="Mobile menu">
-						<li><a href="#" role="button" class="nToggleMenu" data-target=".navbar-responsive-collapse" data-toggle="collapse">
+						<li><a href="#" role="button" data-target=".navbar-responsive-collapse" data-toggle="collapse">
 							<span class="icon" aria-hidden="true"><i class="fa fa-bars"></i></span><br>Menu
 						</a></li>
 						<li><a href="/products">


### PR DESCRIPTION
When opening the menu on mobile the animation is clunky and gross. Removing this class fixes the issue and causes no other ill effects that I can see. Probably there is some JS somewhere attached to the nToggleMenu class. But it's useless.  