### PR TITLE
Update build scripts to allow gulp as a local dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ If you are compiling `.scss` files for the purpose of contributing to Skeletal, 
 _Note that steps 1 and 2 only need to be completed once per system, so no need to repeat them again._
 
 1. Install [node.js](https://nodejs.org/),
-2. Install Gulp globally with `npm i -g gulp` in your terminal, if you have not already,
-3. CD into your local folder of Skeletal and run the `npm i` command to install all relevant dependencies,
-4. Run `gulp` — this will now watch your `.scss` files and compile them as they change.
+2. CD into your local folder of Skeletal and run the `npm i` command to install all relevant dependencies,
+3. Run either of these two commands:
+    - `npm run build` — this will compile your `.scss` files.
+    - `npm run watch` — this will watch your `.scss` files and compile them as they change.
 
 ## Testing
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,4 +31,6 @@ gulp.task('watch', ['sass'], function() {
 	gulp.watch([config.SCSS + '/*.scss', config.SCSS + '/_*.scss'], ['sass']);
 });
 
+gulp.task('build', ['sass', 'js']);
+
 gulp.task('default', ['watch']);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
 	"main": "gulpfile.js",
 	"scripts": {
 		"compile": "node_modules/.bin/ntheme compile",
+		"build": "gulp build",
+		"watch": "gulp watch",
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
 	"repository": {


### PR DESCRIPTION
Nobody likes global dependencies.