### PR TITLE
Custom.js addToWishList params

### DIFF
--- a/src/js/custom.js
+++ b/src/js/custom.js
@@ -10,7 +10,9 @@
 				'textclass': 'wishlist_text',
 				'htmlon': '<i class="fas fa-star" aria-hidden="true"></i>',
 				'htmloff': '<i class="far fa-star" aria-hidden="true"></i> Wishlist',
-				'tooltip_css': 'whltooltips'
+				'tooltip_css': 'whltooltips',
+				'imageon': '',
+				'imageoff': ''
 			});
 			// Ajax Add To Cart
 			$.addToCartInit({


### PR DESCRIPTION
These images were probably used by wishlist popup interface in the past. Since they aren't anymore, the images are still being preloaded when they don't need to be. From a performance perspective this is negligible however since it loads after the dom renders it means its one more thing certain site performance checkers will treat as a false positive, potentially increasing the reported page load times.