### PR TITLE
Remove the cache functions from product thumbnails

### DIFF
--- a/src/templates/thumbs/product/box.template.html
+++ b/src/templates/thumbs/product/box.template.html
@@ -1,4 +1,3 @@
-[%CACHE type:'box' id:'[@inventory_id@]'%]
 <li class="list-group-item thumbnail-box border-0" role="article" aria-label="Product Thumbnail">
 	<div class="row">
 		<div class="col-12 col-lg-5">
@@ -31,4 +30,3 @@
 		</div>
 	</div>
 </li>
-[%/ CACHE%]

--- a/src/templates/thumbs/product/list.template.html
+++ b/src/templates/thumbs/product/list.template.html
@@ -1,4 +1,3 @@
-[%cache type:'list' id:'[@inventory_id@]'%]
 	<article class="col-12 pb-2" role="article" aria-label="Product Thumbnail">
 		<div class="card" itemscope itemtype="http://schema.org/Product">
 			<meta itemprop="brand" content="[@brand@]"/>
@@ -60,4 +59,3 @@
 			</div>
 		</div>
 	</article>
-[%/cache%]

--- a/src/templates/thumbs/product/template.html
+++ b/src/templates/thumbs/product/template.html
@@ -1,4 +1,3 @@
-[%CACHE type:'gallery' id:'[@inventory_id@]'%]
 <article class="col-8 col-sm-6 col-lg-4 col-xl-3 pb-2" role="article" aria-label="Product thumbnail">
 	<div class="card thumbnail card-body" itemscope itemtype="http://schema.org/Product">
 		<meta itemprop="brand" content="[@brand@]"/>
@@ -52,4 +51,3 @@
 		</div>
 	</div>
 </article>
-[%/CACHE%]


### PR DESCRIPTION
These offer basically no performance boost since the template file contents does not
include any functions that require further requests to the database. 

All they do is make it more inconvenient to make copies of the templates
when you forget to change the cache key. Or prevent to implementing page based data on the thumbnail template for things like advanced google analytics