### PR TITLE
Fix issue where category and instock filters could not be toggled off once selected

### DIFF
--- a/src/templates/cms/includes/sidebar.template.html
+++ b/src/templates/cms/includes/sidebar.template.html
@@ -32,7 +32,7 @@
 						[%/param%]
 						[%param *body%]
 							[%if [@selected@]%]
-								<a class="filter-remove filter text-dark list-group-item list-group-item-action d-flex justify-content-between align-items-center" href="[@remove_single_url@]" rel="nofollow">
+								<a class="filter-remove filter text-dark list-group-item list-group-item-action d-flex justify-content-between align-items-center" href="[@remove_url@]" rel="nofollow">
 									<span><i class="fa fa-check-square"></i> [@name@]</span>
 									<span class="badge badge-secondary badge-pill">[@total@]</span>
 								</a>
@@ -50,7 +50,7 @@
 						[%/param%]
 						[%param *body%]
 							[%if [@selected@]%]
-								<a class="filter-remove filter text-dark list-group-item list-group-item-action d-flex justify-content-between align-items-center" href="[@remove_single_url@]" rel="nofollow">
+								<a class="filter-remove filter text-dark list-group-item list-group-item-action d-flex justify-content-between align-items-center" href="[@remove_url@]" rel="nofollow">
 									<span><i class="fa fa-check-square"></i> In Stock</span>
 									<span class="badge badge-secondary badge-pill">[@total@]</span>
 								</a>


### PR DESCRIPTION
The `[@remove_single_url@]` tag only returns a value when the `product_filter` is of type `variations`.

I tried changing the variation filter to use the `[@remove_url@]` too, but this removes all variations from the current filter, not just the one clicked. 