### PR TITLE
Made "filter products" heading a block element

### DIFF
--- a/src/templates/cms/includes/sidebar.template.html
+++ b/src/templates/cms/includes/sidebar.template.html
@@ -3,7 +3,7 @@
 		<div class="card mb-2">
 			<div class="card-header border-bottom">
 				<h3 class="h4 mb-0">
-					<a class="text-dark" role="button" data-toggle="collapse" aria-expanded="false" href="#filters" aria-controls="#filters">Filter Products</a>
+					<a class="text-dark d-block" role="button" data-toggle="collapse" aria-expanded="false" href="#filters" aria-controls="#filters">Filter Products</a>
 				</h3>
 			</div>
 			<div id="filters" class="collapse">


### PR DESCRIPTION
This means that even if you mash the screen with your fat thumb the filters panel will still open. 

E.g. You just need to hit the panel, rather than the text itself.

