### PR TITLE
Added missing position schema data

### DIFF
--- a/src/templates/cms/category.template.html
+++ b/src/templates/cms/category.template.html
@@ -2,8 +2,8 @@
 [%load_template file:'cms/includes/sidebar.template.html'/%]
 [%breadcrumb%]
 	[%param *header%]
-		<nav aria-label="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
-			<ol class="breadcrumb">
+		<nav aria-label="breadcrumb">
+			<ol class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
 				<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
 					<a href="[@config:home_url@]" itemprop="item"><span itemprop="name">Home</span></a>
 					<meta itemprop="position" content="0" />

--- a/src/templates/cms/category.template.html
+++ b/src/templates/cms/category.template.html
@@ -2,20 +2,22 @@
 [%load_template file:'cms/includes/sidebar.template.html'/%]
 [%breadcrumb%]
 	[%param *header%]
-	<nav aria-label="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
-		<ol class="breadcrumb">
-			<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-				<a href="[@config:home_url@]" itemprop="item"><span itemprop="name">Home</span></a>
-			</li>
+		<nav aria-label="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
+			<ol class="breadcrumb">
+				<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+					<a href="[@config:home_url@]" itemprop="item"><span itemprop="name">Home</span></a>
+					<meta itemprop="position" content="0" />
+				</li>
 	[%/param%]
 	[%param *body%]
-		<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-			<a href="[@url@]" itemprop="item"><span itemprop="name">[@name@]</span></a>
-		</li>
+				<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+					<a href="[@url@]" itemprop="item"><span itemprop="name">[@name@]</span></a>
+					<meta itemprop="position" content="[%calc [@count@] + 1 /%]" />
+				</li>
 	[%/param%]
 	[%param *footer%]
-		</ol>
-	</nav>
+			</ol>
+		</nav>
 	[%/param%]
 [%/breadcrumb%]
 <h1 class="page-header">

--- a/src/templates/products/template.html
+++ b/src/templates/products/template.html
@@ -4,18 +4,20 @@
 		[%breadcrumb%]
 			[%param *header%]
 				<nav aria-label="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
-				<ol class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
-					<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-						<a href="[@config:home_url@]" itemprop="item"><span itemprop="name">Home</span></a>
-					</li>
+					<ol class="breadcrumb">
+						<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+							<a href="[@config:home_url@]" itemprop="item"><span itemprop="name">Home</span></a>
+							<meta itemprop="position" content="0" />
+						</li>
 			[%/param%]
 			[%param *body%]
-				<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-					<a href="[@url@]" itemprop="item"><span itemprop="name">[@name@]</span></a>
-				</li>
+						<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+							<a href="[@url@]" itemprop="item"><span itemprop="name">[@name@]</span></a>
+							<meta itemprop="position" content="[%calc [@count@] + 1 /%]" />
+						</li>
 			[%/param%]
 			[%param *footer%]
-				</ol>
+					</ol>
 				</nav>
 			[%/param%]
 		[%/breadcrumb%]

--- a/src/templates/products/template.html
+++ b/src/templates/products/template.html
@@ -3,8 +3,8 @@
 	<div class="col-12">
 		[%breadcrumb%]
 			[%param *header%]
-				<nav aria-label="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
-					<ol class="breadcrumb">
+				<nav aria-label="breadcrumb">
+					<ol class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
 						<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
 							<a href="[@config:home_url@]" itemprop="item"><span itemprop="name">Home</span></a>
 							<meta itemprop="position" content="0" />


### PR DESCRIPTION
BreadcrumbList is missing the position schema data. There was also a double up of the BreadcrumbList itemtype.

https://search.google.com/structured-data/testing-tool#url=http%3A%2F%2Fskeletaltheme.neto.com.au%2Fsample-product-1