### PR TITLE
Accordion links on product page are now block elements

### DIFF
--- a/src/templates/products/includes/product_information.template.html
+++ b/src/templates/products/includes/product_information.template.html
@@ -43,7 +43,7 @@
             <div class="card">
                 <div class="card-header py-1 px-2" id="headingDescription">
                     <h5 class="mb-0">
-                        <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#accordionDescription" aria-expanded="true" aria-controls="accordionDescription">
+                        <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#accordionDescription" aria-expanded="true" aria-controls="accordionDescription">
                             Description
                         </button>
                     </h5>
@@ -65,7 +65,7 @@
                 <div class="card">
                     <div class="card-header py-1 px-2" id="headingWarranty">
                         <h5 class="mb-0">
-                            <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#accordionWarranty" aria-expanded="true" aria-controls="accordionWarranty">
+                            <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#accordionWarranty" aria-expanded="true" aria-controls="accordionWarranty">
                                 Warranty
                             </button>
                         </h5>
@@ -85,7 +85,7 @@
                 <div class="card">
                     <div class="card-header py-1 px-2" id="headingFeatures">
                         <h5 class="mb-0">
-                            <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#accordionFeatures" aria-expanded="true" aria-controls="accordionFeatures">
+                            <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#accordionFeatures" aria-expanded="true" aria-controls="accordionFeatures">
                                 Features
                             </button>
                         </h5>
@@ -104,7 +104,7 @@
             <div class="card">
                 <div class="card-header py-1 px-2" id="headingSpecificatoin">
                     <h5 class="mb-0">
-                        <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#accordionSpecifications" aria-expanded="true" aria-controls="accordionSpecifications">
+                        <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#accordionSpecifications" aria-expanded="true" aria-controls="accordionSpecifications">
                             Specifications
                         </button>
                     </h5>
@@ -223,7 +223,7 @@
                 <div class="card">
                     <div class="card-header py-1 px-2" id="headingTnc">
                         <h5 class="mb-0">
-                            <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#accordionTnc" aria-expanded="true" aria-controls="accordionTnc">
+                            <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#accordionTnc" aria-expanded="true" aria-controls="accordionTnc">
                                 Terms and Conditions
                             </button>
                         </h5>
@@ -243,7 +243,7 @@
                 <div class="card">
                     <div class="card-header py-1 px-2" id="headingReviews">
                         <h5 class="mb-0">
-                            <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#accordionReviews" aria-expanded="true" aria-controls="accordionReviews">
+                            <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#accordionReviews" aria-expanded="true" aria-controls="accordionReviews">
                                 Reviews
                                 [%set [@data:ratings-count@] = 1 /%]
                                 [%while [@data:ratings-count@] <= [@data:rating@]%]


### PR DESCRIPTION
Accordion links should be block elements for ease of use.