### PR TITLE
iOS Select Option Overflow

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -1567,6 +1567,8 @@ pre {
   background-clip: padding-box;
   border: 1px solid #ced4da;
   border-radius: 0.25rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
   -webkit-transition: border-color 0.15s ease-in-out, -webkit-box-shadow 0.15s ease-in-out;
   transition: border-color 0.15s ease-in-out, -webkit-box-shadow 0.15s ease-in-out;
   transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;


### PR DESCRIPTION
This fix stops long select option names from causing iOS to side scroll on product pages with select boxes.