### PR TITLE
iOS Select Option Overflow

### DIFF
--- a/src/scss/_neto.scss
+++ b/src/scss/_neto.scss
@@ -345,6 +345,8 @@ $payment-icon:(
 #suburb_sl,
 ._itmspec_opt,
 .n-wrapper-form-control select {
+	overflow: hidden;
+	text-overflow: ellipsis;
 	@extend .form-control;
 	@extend select.form-control;
 }


### PR DESCRIPTION
This fix stops long select option names from causing iOS to side scroll on product pages.