### PR TITLE
Adding content level for nested content/content with a parent page

### DIFF
--- a/src/templates/cms/default.template.html
+++ b/src/templates/cms/default.template.html
@@ -74,7 +74,7 @@
 		[%/parse%]
 	</section>
 [%/if%]
-[%thumb_list type:'content' content_type:'' template:'' limit:'20'%]
+[%thumb_list type:'content' content_type:'' template:'' show_next_level:'[@content_level@]' limit:'20'%]
 	[%param *footer%]
 		<nav aria-label="Page navigation">
 			<ul class="pagination">


### PR DESCRIPTION
At the moment, the Skeletal theme doesn't provide a way of nesting content pages which have a parent set on the page.

Have added ` show_next_level:'[@content_level@]' ` to enable this functionality. Has been tested in our theme at Jetblack Espresso and works well (see https://www.jetblackespresso.com.au/exploded-views/ for example)