### PR TITLE
Hotfix/home template div wrapper

### DIFF
--- a/src/templates/cms/default.template.html
+++ b/src/templates/cms/default.template.html
@@ -74,7 +74,7 @@
 		[%/parse%]
 	</section>
 [%/if%]
-[%thumb_list type:'content' content_type:'' template:'' limit:'20'%]
+[%thumb_list type:'content' content_type:'' template:'' show_next_level:'[@content_level@]' limit:'20'%]
 	[%param *footer%]
 		<nav aria-label="Page navigation">
 			<ul class="pagination">

--- a/src/templates/cms/home.template.html
+++ b/src/templates/cms/home.template.html
@@ -1,4 +1,5 @@
 [%load_template file:'cms/includes/sidebar.template.html'/%]
+<div class="col-sm-12">
 	[%if [@config:show_home_ads@]%]
 		[%advert type:'text' template:'carousel' limit:'10' ad_group:''%]
 			[%param *header%]


### PR DESCRIPTION
Currently skeletal on a mobile device has no padding on the front page. Compared to [Take me home](https://github.com/NetoECommerce/Take-Me-Home-Theme/blob/master/src/templates/cms/home.template.html) it seemed this tag was missing, as the root of the problem.