### PR TITLE
Added 'position' schema data to Breadcrumb function on all CMS templates

### DIFF
--- a/src/templates/cms/default.template.html
+++ b/src/templates/cms/default.template.html
@@ -1,22 +1,24 @@
 [%load_template file:'cms/includes/sidebar.template.html'/%]
-[%breadcrumb%]
-	[%PARAM *header%]
-		<nav aria-label="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
-		<ol class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
-			<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-				<a href="[@config:home_url@]" itemprop="item"><span itemprop="name">Home</span></a>
-			</li>
-	[%/PARAM%]
-	[%PARAM *body%]
-		<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-			<a href="[@url@]" itemprop="item"><span itemprop="name">[@name@]</span></a>
-		</li>
-	[%/PARAM%]
-	[%PARAM *footer%]
-		</ol>
-		</nav>
-	[%/PARAM%]
-[%/breadcrumb%]
+	[%breadcrumb%]
+		[%param *header%]
+			<nav aria-label="breadcrumb">
+				<ol class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
+					<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+						<a href="[@config:home_url@]" itemprop="item"><span itemprop="name">Home</span></a>
+						<meta itemprop="position" content="0" />
+					</li>
+		[%/param%]
+		[%param *body%]
+					<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+						<a href="[@url@]" itemprop="item"><span itemprop="name">[@name@]</span></a>
+						<meta itemprop="position" content="[%calc [@count@] + 1 /%]" />
+					</li>
+		[%/param%]
+		[%param *footer%]
+				</ol>
+			</nav>
+		[%/param%]
+	[%/breadcrumb%]
 <h1 class="display-4">
 	[%url_info name:'page_heading' default:'[@content_name@]'/%]
 </h1>

--- a/src/templates/cms/products.template.html
+++ b/src/templates/cms/products.template.html
@@ -2,18 +2,20 @@
 [%breadcrumb%]
 	[%param *header%]
 		<nav aria-label="breadcrumb">
-		<ol class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
-			<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-				<a href="[@config:home_url@]" itemprop="item"><span itemprop="name">Home</span></a>
-			</li>
+			<ol class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
+				<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+					<a href="[@config:home_url@]" itemprop="item"><span itemprop="name">Home</span></a>
+					<meta itemprop="position" content="0" />
+				</li>
 	[%/param%]
 	[%param *body%]
-		<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-			<a href="[@url@]" itemprop="item"><span itemprop="name">[@name@]</span></a>
-		</li>
+				<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+					<a href="[@url@]" itemprop="item"><span itemprop="name">[@name@]</span></a>
+					<meta itemprop="position" content="[%calc [@count@] + 1 /%]" />
+				</li>
 	[%/param%]
 	[%param *footer%]
-		</ul>
+			</ol>
 		</nav>
 	[%/param%]
 [%/breadcrumb%]

--- a/src/templates/cms/search_results.template.html
+++ b/src/templates/cms/search_results.template.html
@@ -2,20 +2,22 @@
 [%load_template file:'cms/includes/sidebar.template.html'/%]
 	[%breadcrumb%]
 		[%param *header%]
-		<nav aria-label="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
-			<ol class="breadcrumb">
-				<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-					<a href="[@config:home_url@]" itemprop="item"><span itemprop="name">Home</span></a>
-				</li>
+			<nav aria-label="breadcrumb">
+				<ol class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
+					<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+						<a href="[@config:home_url@]" itemprop="item"><span itemprop="name">Home</span></a>
+						<meta itemprop="position" content="0" />
+					</li>
 		[%/param%]
 		[%param *body%]
-			<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-				<a href="[@url@]" itemprop="item"><span itemprop="name">[@name@]</span></a>
-			</li>
+					<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+						<a href="[@url@]" itemprop="item"><span itemprop="name">[@name@]</span></a>
+						<meta itemprop="position" content="[%calc [@count@] + 1 /%]" />
+					</li>
 		[%/param%]
 		[%param *footer%]
-			</ol>
-		</nav>
+				</ol>
+			</nav>
 		[%/param%]
 	[%/breadcrumb%]
 	[%filter ID:'keywords' if:'ne' value:''%]

--- a/src/templates/cms/store_finder.template.html
+++ b/src/templates/cms/store_finder.template.html
@@ -1,21 +1,23 @@
 [%load_template file:'cms/includes/sidebar.template.html'/%]
 	[%breadcrumb%]
-		[%PARAM *header%]
-			<nav aria-label="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
-			<ol class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
-				<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-					<a href="[@config:home_url@]" itemprop="item"><span itemprop="name">Home</span></a>
-				</li>
-		[%/PARAM%]
-		[%PARAM *body%]
-			<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-				<a href="[@url@]" itemprop="item"><span itemprop="name">[@name@]</span></a>
-			</li>
-		[%/PARAM%]
-		[%PARAM *footer%]
-			</ol>
+		[%param *header%]
+			<nav aria-label="breadcrumb">
+				<ol class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
+					<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+						<a href="[@config:home_url@]" itemprop="item"><span itemprop="name">Home</span></a>
+						<meta itemprop="position" content="0" />
+					</li>
+		[%/param%]
+		[%param *body%]
+					<li class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+						<a href="[@url@]" itemprop="item"><span itemprop="name">[@name@]</span></a>
+						<meta itemprop="position" content="[%calc [@count@] + 1 /%]" />
+					</li>
+		[%/param%]
+		[%param *footer%]
+				</ol>
 			</nav>
-		[%/PARAM%]
+		[%/param%]
 	[%/breadcrumb%]
 	<h1>[@content_name@]</h1>
 	<hr aria-hidden="true"/>


### PR DESCRIPTION
This new breadcrumb already existed on the category template and product template but didn't seem to be applied on other pages. This was giving schema data errors as can be seen here:  [https://search.google.com/structured-data/testing-tool/u/0/#url=http%3A%2F%2Fskeletaltheme.neto.com.au%2Fabout_us](url)