### PR TITLE
Hotfix/cms template div wrapper

### DIFF
--- a/src/templates/cms/category.template.html
+++ b/src/templates/cms/category.template.html
@@ -1,5 +1,6 @@
 [%SET [@page_type@]='category'/%]
 [%load_template file:'cms/includes/sidebar.template.html'/%]
+[%load_template file:'cms/includes/wrapper.template.html'/%]
 [%breadcrumb%]
 	[%param *header%]
 		<nav aria-label="breadcrumb">

--- a/src/templates/cms/default.template.html
+++ b/src/templates/cms/default.template.html
@@ -1,4 +1,5 @@
 [%load_template file:'cms/includes/sidebar.template.html'/%]
+[%load_template file:'cms/includes/wrapper.template.html'/%]
 [%breadcrumb%]
 	[%PARAM *header%]
 		<nav aria-label="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">

--- a/src/templates/cms/home.template.html
+++ b/src/templates/cms/home.template.html
@@ -1,4 +1,5 @@
 [%load_template file:'cms/includes/sidebar.template.html'/%]
+[%load_template file:'cms/includes/wrapper.template.html'/%]
 	[%if [@config:show_home_ads@]%]
 		[%advert type:'text' template:'carousel' limit:'10' ad_group:''%]
 			[%param *header%]

--- a/src/templates/cms/includes/sidebar.template.html
+++ b/src/templates/cms/includes/sidebar.template.html
@@ -219,4 +219,3 @@
 		[%/param%]
 	[%/MENU%]
 </aside>
-<div class="col-12 col-md-9">

--- a/src/templates/cms/includes/wrapper.template.html
+++ b/src/templates/cms/includes/wrapper.template.html
@@ -1,0 +1,1 @@
+<div class="col-12 col-md-9">

--- a/src/templates/cms/products.template.html
+++ b/src/templates/cms/products.template.html
@@ -1,4 +1,5 @@
 [%load_template file:'cms/includes/sidebar.template.html'/%]
+[%load_template file:'cms/includes/wrapper.template.html'/%]
 [%breadcrumb%]
 	[%param *header%]
 		<nav aria-label="breadcrumb">

--- a/src/templates/cms/search_results.template.html
+++ b/src/templates/cms/search_results.template.html
@@ -1,5 +1,6 @@
 [%SET [@page_type@]='category'/%]
 [%load_template file:'cms/includes/sidebar.template.html'/%]
+[%load_template file:'cms/includes/wrapper.template.html'/%]
 	[%breadcrumb%]
 		[%param *header%]
 		<nav aria-label="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">

--- a/src/templates/cms/store_finder.template.html
+++ b/src/templates/cms/store_finder.template.html
@@ -1,4 +1,5 @@
 [%load_template file:'cms/includes/sidebar.template.html'/%]
+[%load_template file:'cms/includes/wrapper.template.html'/%]
 	[%breadcrumb%]
 		[%PARAM *header%]
 			<nav aria-label="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">


### PR DESCRIPTION
Ok so this is my second crack, after #456 didn't meet requirements.

What I propose is a second include on every cms template of 'wrapper' which includes the single line "<div class="col-12 col-md-9">".
This solves the DRY problem requiring an update of the wrapping div on multiple pages, but also decouples the templates from a dependency on 'sidebar' for their wrapping div.

It doesn't feel all that elegant however - a better solution as noted in #456 would be to have a layout template that itself imports the cms templates within a wrapping div.

This may cause breaking changes for anyone who has created an additional template (templates\cms\example.template.html) which imports the current sidebar.template.html