### PR TITLE
btn-link to theme editor styles

### DIFF
--- a/src/css/skeletal-style.css
+++ b/src/css/skeletal-style.css
@@ -6,11 +6,10 @@ body {
 	background-color: #fff /*{body-background-colour}*/;
 }
 
-a {
+a, .btn-link{
 	color: #006FF5 /*{link-text-colour}*/;
 }
-a:hover,
-a:focus {
+a:hover, a:active, a:focus, .btn-link:hover{
 	color: #004ca9 /*{link-text-hover-colour}*/;
 }
 


### PR DESCRIPTION
@jakesergeant found this issue on a child theme, so bringing the fix over. 
`btn-link` is used on product page mobile accordions.