### PR TITLE
paypal_express_js tag over logic in template

### DIFF
--- a/src/templates/cart/shopping_cart.template.html
+++ b/src/templates/cart/shopping_cart.template.html
@@ -268,21 +268,7 @@
 								[%checkout_payment type:'[@order_type@]' reload:'1' distinct:'1'%]
 									[%param *body%]
 										[%if [@payment_desc_type@] eq 'paypalexpress'%]
-											[%if [@config:PAYPAL_MERCHANT_ID@] ne ''%]
-												[%SITE_VALUE id:'footer_javascript'%]
-													<script>
-														window.paypalCheckoutReady = function() {
-															paypal.checkout.setup(
-																"[%nohtml%][@config:paypal_merchant_id@][%/nohtml%]", {
-																	environment: "[%if [@config:paypal_api_environment@] eq 'sandbox'%]sandbox[%else%]live[%/if%]",
-																	button: 'paypal'
-																}
-															);
-														};
-													</script>
-													<script src="//www.paypalobjects.com/api/checkout.js" async></script>
-												[%/ SITE_VALUE%]
-											[%/if%]
+											[%site_value id:'footer_javascript'%][%paypal_express_js /%][%/site_value%]
 											<a id="paypal" class="_cpy_thirdparty_btn" ref="paypal" href="[%URL page:'checkout' fn:'3rdparty' qs:'payment=6'/%]">
 												<img src="https://www.paypalobjects.com/webstatic/en_US/i/btn/png/gold-rect-paypalcheckout-60px.png" alt="Checkout With Paypal" height="46">
 											</a>


### PR DESCRIPTION
The current paypal implementation should be wrapped in an iife and should be aligned with the same implementation as on the checkout. 

This implementation allows better control on how Paypal is implemented across the board for all merchant webstores, and if the API changes, then we have a way to update existing sites without editing the merchant's templates. There isn't really a use case for the merchant wanting control over this as there isn't much that can change with this:

- https://developer.paypal.com/docs/classic/express-checkout/in-context/javascript_advanced_settings/#setup

But if merchants want more control over how `paypalCheckoutReady` is setup, then they have Skeletal commit history.

**Note: this tag isn't available until 6.41.0** Created as PR so we can get started on testing.
