### PR TITLE
Update no shipping methods logic to check for ship_zip

### DIFF
--- a/src/templates/cart/shopping_cart.template.html
+++ b/src/templates/cart/shopping_cart.template.html
@@ -193,7 +193,7 @@
 								</tr>
 							[%/param%]
 							[%param *ifempty%]
-								[%if [@ship_country@]%]
+								[%if [@ship_zip@]%]
 									<b class="text-danger">Shipping not available to [%if [@ship_zip@]%][@ship_zip@] [%/if%][%countries%][%param *body%][%if [@country_code@] eq [@ship_country@]%][@country_name@][%/if%][%/param%][%/countries%], please try another location.</b>
 								[%else%]
 									Use shipping calculator to calculate shipping

--- a/src/templates/products/includes/shipping_calc.template.html
+++ b/src/templates/products/includes/shipping_calc.template.html
@@ -112,7 +112,7 @@
 				</div>
 			[%/ param%]
 			[%param *ifempty%]
-				[%if [@ship_country@]%]
+				[%if [@ship_zip@]%]
 					<br /><p class="alert alert-danger alert-shipping-error" aria-label="alert" role="alert" aria-atomic="true">Shipping not available to [%if [@ship_zip@]%][@ship_zip@] [%/if%][@ship_country@], please try another location.</p>
 				[%/if%]
 			[%/ param%]


### PR DESCRIPTION
Fixes issue where error message would be shown before user enters a postcode:
![Screen Shot 2019-03-14 at 1 43 50 pm](https://user-images.githubusercontent.com/6867163/54329855-3ebe3100-465f-11e9-838f-9b7e8b74678c.png)

This issue occurs on all sites that don't have a flat-rate shipping method set up. 