### PR TITLE
Restore nofollow for filter links

### DIFF
--- a/src/templates/cms/includes/sidebar.template.html
+++ b/src/templates/cms/includes/sidebar.template.html
@@ -19,7 +19,7 @@
 									<span class="badge badge-secondary badge-pill">[@total@]</span>
 								</a>
 							[%else%]
-								<a class="filter text-dark list-group-item list-group-item-action d-flex justify-content-between align-items-center" href="[@url@]" aria-label="Filter [@filter_name@] to [@name@]">
+								<a class="filter text-dark list-group-item list-group-item-action d-flex justify-content-between align-items-center" href="[@url@]" aria-label="Filter [@filter_name@] to [@name@]" rel="nofollow">
 									<span><i class="far fa-square"></i> [@name@]</span>
 									<span class="badge badge-secondary badge-pill">[@total@]</span>
 								</a>
@@ -37,7 +37,7 @@
 									<span class="badge badge-secondary badge-pill">[@total@]</span>
 								</a>
 							[%else%]
-								<a class="filter text-dark list-group-item list-group-item-action d-flex justify-content-between align-items-center" href="[@url@]" aria-label="Filter [@filter_name@] to [@name@]">
+								<a class="filter text-dark list-group-item list-group-item-action d-flex justify-content-between align-items-center" href="[@url@]" aria-label="Filter [@filter_name@] to [@name@]" rel="nofollow">
 									<span><i class="far fa-square"></i> [@name@]</span>
 									<span class="badge badge-secondary badge-pill">[@total@]</span>
 								</a>
@@ -55,7 +55,7 @@
 									<span class="badge badge-secondary badge-pill">[@total@]</span>
 								</a>
 							[%else%]
-								<a class="filter text-dark list-group-item list-group-item-action d-flex justify-content-between align-items-center" href="[@url@]">
+								<a class="filter text-dark list-group-item list-group-item-action d-flex justify-content-between align-items-center" href="[@url@]" rel="nofollow">
 									<span><i class="far fa-square"></i> In Stock</span>
 									<span class="badge badge-secondary badge-pill">[@total@]</span>
 								</a>
@@ -74,11 +74,11 @@
 								</a>
 							[%else%]
 								[%if [@min@] == 0 AND [@max@] > 0%]
-									<a class="text-dark filter list-group-item d-l-none d-xl-none" href="[@url@]"><i class="far fa-square"></i> [%format type:'currency' dp:'0'%][@max@][%/format%] or below</a>
+									<a class="text-dark filter list-group-item d-l-none d-xl-none" href="[@url@]" rel="nofollow"><i class="far fa-square"></i> [%format type:'currency' dp:'0'%][@max@][%/format%] or below</a>
 								[%elseif [@min@] > 0 AND [@max@] > 0%]
-									<a class="text-dark filter list-group-item d-l-none d-xl-none" href="[@url@]"><i class="far fa-square"></i> [%format type:'currency' dp:'0'%][@min@][%/format%] to [%format type:'currency' dp:'0'%][@max@][%/format%]</a>
+									<a class="text-dark filter list-group-item d-l-none d-xl-none" href="[@url@]" rel="nofollow"><i class="far fa-square"></i> [%format type:'currency' dp:'0'%][@min@][%/format%] to [%format type:'currency' dp:'0'%][@max@][%/format%]</a>
 								[%elseif [@max@] == 0%]
-									<a class="text-dark filter list-group-item d-l-none d-xl-none" href="[@url@]"><i class="far fa-square"></i> [%format type:'currency' dp:'0'%][@min@][%/format%] or above</a>
+									<a class="text-dark filter list-group-item d-l-none d-xl-none" href="[@url@]" rel="nofollow"><i class="far fa-square"></i> [%format type:'currency' dp:'0'%][@min@][%/format%] or above</a>
 								[%/if%]
 							[%/if%]
 						[%/param%]
@@ -132,7 +132,7 @@
 									<span class="badge badge-secondary badge-pill">[@total@]</span>
 								</a>
 							[%else%]
-								<a class="text-dark filter list-group-item d-flex justify-content-between align-items-center" href="[@url@]">
+								<a class="text-dark filter list-group-item d-flex justify-content-between align-items-center" href="[@url@]" rel="nofollow">
 									<span><i class="far fa-square"></i> [@brand@]</span>
 									<span class="badge badge-secondary badge-pill">[@total@]</span>
 								</a>


### PR DESCRIPTION
At some point it looks like `rel="nofollow"` was removed from half of the filter links. 

This PR adds it back in. 