### PR TITLE
Added srcset tags to product thumbnails

### DIFF
--- a/src/templates/thumbs/product/box.template.html
+++ b/src/templates/thumbs/product/box.template.html
@@ -3,7 +3,9 @@
 	<div class="row">
 		<div class="col-12 col-lg-5">
 			<a href="[@URL@]" title="[@model@]">
-				<img src="[%asset_url type:'product' thumb:'thumb' id:'[@SKU@]'%][%param default%][%cdn_asset html:'0' library:'images'%]default_product.gif[%/cdn_asset%][%end param%][%/ asset_url%]" class="product-image img-fluid" width="100%" alt="[@model@]" rel="itmimg[@SKU@]">
+				[%set [@thumb@] %][%asset_url type:'product' thumb:'thumb' id:'[@SKU@]'%][%param default%][%cdn_asset html:'0' library:'images'%]default_product.gif[%/cdn_asset%][%end param%][%/asset_url%][%/set%]
+				[%set [@thumbL@] %][%asset_url type:'product' thumb:'thumbL' id:'[@SKU@]'%][%param default%][%cdn_asset html:'0' library:'images'%]default_product.gif[%/cdn_asset%][%end param%][%/asset_url%][%/set%]
+				<img srcset="[@thumb@] 200w, [@thumbL@] 350w, [@thumbL@] 2x" src="[@thumb@]" class="product-image img-fluid" width="100%" alt="[@model@]" rel="itmimg[@SKU@]">
 			</a>
 			[%if [@inpromo@]%]
 				<div class="savings-container"><span class="badge badge-danger">On Sale</span></div>

--- a/src/templates/thumbs/product/list.template.html
+++ b/src/templates/thumbs/product/list.template.html
@@ -7,7 +7,9 @@
 				<div class="row">
 					<div class="col-4 col-md-3">
 						<a href="[@URL@]" class="thumbnail-image">
-							<img src="[%asset_url type:'product' thumb:'thumb' id:'[@sku@]'%][%param default%][%cdn_asset html:'0' library:'images'%]default_product.gif[%/cdn_asset%][%/param%][%/asset_url%]" itemprop="image" class="product-image img-fluid" alt="[@model@]" rel="itmimg[@sku@]">
+								[%set [@thumb@] %][%asset_url type:'product' thumb:'thumb' id:'[@SKU@]'%][%param default%][%cdn_asset html:'0' library:'images'%]default_product.gif[%/cdn_asset%][%end param%][%/asset_url%][%/set%]
+								[%set [@thumbL@] %][%asset_url type:'product' thumb:'thumbL' id:'[@SKU@]'%][%param default%][%cdn_asset html:'0' library:'images'%]default_product.gif[%/cdn_asset%][%end param%][%/asset_url%][%/set%]
+							<img srcset="[@thumb@] 200w, [@thumbL@] 350w, [@thumbL@] 2x" src="[@thumb@]" itemprop="image" class="product-image img-fluid" alt="[@model@]" rel="itmimg[@sku@]">
 						</a>
 					</div>
 					<div class="col-8 col-md-6">

--- a/src/templates/thumbs/product/template.html
+++ b/src/templates/thumbs/product/template.html
@@ -4,7 +4,9 @@
 		<meta itemprop="brand" content="[@brand@]"/>
 		<meta itemprop="mpn" content="[@sku@]"/>
 		<a href="[@URL@]" class="thumbnail-image pb-2">
-			<img src="[%asset_url type:'product' thumb:'thumb' id:'[@SKU@]'%][%param default%][%cdn_asset html:'0' library:'images'%]default_product.gif[%/cdn_asset%][%end param%][%/asset_url%]" itemprop="image" class="product-image img-fluid" alt="[@model@]" rel="itmimg[@SKU@]">
+			[%set [@thumb@] %][%asset_url type:'product' thumb:'thumb' id:'[@SKU@]'%][%param default%][%cdn_asset html:'0' library:'images'%]default_product.gif[%/cdn_asset%][%end param%][%/asset_url%][%/set%]
+			[%set [@thumbL@] %][%asset_url type:'product' thumb:'thumbL' id:'[@SKU@]'%][%param default%][%cdn_asset html:'0' library:'images'%]default_product.gif[%/cdn_asset%][%end param%][%/asset_url%][%/set%]
+			<img srcset="[@thumb@] 200w, [@thumbL@] 350w, [@thumbL@] 2x" src="[@thumb@]" itemprop="image" class="product-image img-fluid" alt="[@model@]" rel="itmimg[@SKU@]">
 		</a>
 		<p class="card-title h4" itemprop="name"><a href="[@URL@]">[%format type:'text' truemaxlength:'50' rmhtml:'1'%][@model@][%/format%]</a></p>
 		<p class="price" itemprop="offers" itemscope itemtype="http://schema.org/Offer" aria-label="[@model@] price">


### PR DESCRIPTION
There is a point just beneath the xs bootstrap 4 breakpoint (<576px) where the product thumbnail images are pixelated due to being too large. The srcset tag accommodates for this point and also retina devices where the ppi is much higher (2x).

Here is a comparison on an iPhone X.

### Before:
![chrome_ly4cdjC7KU](https://user-images.githubusercontent.com/13617683/56334762-0faa5a80-61dd-11e9-9c25-a85533982da6.png)

### After:
![chrome_bWay8FV83E](https://user-images.githubusercontent.com/13617683/56334766-1507a500-61dd-11e9-92c9-5b67cca4662c.png)

The breakpoints were chosen according to the default thumbnail dimensions of 200 and 500. If a browser does not support the srcset tags, the src tag is used instead which points to the lower res image.