### PR TITLE
Updated sass gulptask

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,10 +1,11 @@
 // -------------------- Required modules --------------------
 var { task, src, dest, watch, series, parallel } = require('gulp'),
 	concat = require('gulp-concat'),
-	cssnext = require('postcss-cssnext'),
 	plumber = require('gulp-plumber'),
 	postcss = require('gulp-postcss'),
-	sass = require('gulp-sass');
+	sass = require('gulp-sass'),
+	autoprefixer = require('autoprefixer'),
+	cssnano = require('cssnano');
 
 // -------------------- Configure object --------------------
 var config = {};
@@ -18,7 +19,10 @@ config.jsFiles = ['node_modules/jquery/dist/jquery.min.js', 'node_modules/popper
 //  -------------------- Gulp Tasks --------------------
 // Compile SASS into CSS
 task('sass', function() {
-	var plugins = [ cssnext ];
+	var plugins = [ 
+		autoprefixer({browsers: ['last 1 version']}),
+		cssnano()
+	];
 	return src(config.SCSS +'/*.scss')
 		.pipe(plumber())
 		.pipe(sass())

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@types/q": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+			"integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
+			"dev": true
+		},
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -21,6 +27,12 @@
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
 			}
+		},
+		"alphanum-sort": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+			"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
+			"dev": true
 		},
 		"amdefine": {
 			"version": "1.0.1",
@@ -316,17 +328,90 @@
 			"dev": true
 		},
 		"autoprefixer": {
-			"version": "7.2.6",
-			"resolved": "http://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
-			"integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
+			"version": "9.5.1",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.1.tgz",
+			"integrity": "sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^2.11.3",
-				"caniuse-lite": "^1.0.30000805",
+				"browserslist": "^4.5.4",
+				"caniuse-lite": "^1.0.30000957",
 				"normalize-range": "^0.1.2",
 				"num2fraction": "^1.2.2",
-				"postcss": "^6.0.17",
-				"postcss-value-parser": "^3.2.3"
+				"postcss": "^7.0.14",
+				"postcss-value-parser": "^3.3.1"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "4.5.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.6.tgz",
+					"integrity": "sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30000963",
+						"electron-to-chromium": "^1.3.127",
+						"node-releases": "^1.1.17"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30000966",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000966.tgz",
+					"integrity": "sha512-qqLQ/uYrpZmFhPY96VuBkMEo8NhVFBZ9y/Bh+KnvGzGJ5I8hvpIaWlF2pw5gqe4PLAL+ZjsPgMOvoXSpX21Keg==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"electron-to-chromium": {
+					"version": "1.3.131",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.131.tgz",
+					"integrity": "sha512-NSO4jLeyGLWrT4mzzfYX8vt1MYCoMI5LxSYAjt0H9+LF/14JyiKJSyyjA6AJTxflZlEM5v3QU33F0ohbPMCAPg==",
+					"dev": true
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"aws-sign2": {
@@ -340,16 +425,6 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
 			"dev": true
-		},
-		"babel-runtime": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"dev": true,
-			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
-			}
 		},
 		"bach": {
 			"version": "1.2.0",
@@ -453,6 +528,12 @@
 				"inherits": "~2.0.0"
 			}
 		},
+		"boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+			"dev": true
+		},
 		"bootstrap": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
@@ -497,16 +578,6 @@
 				}
 			}
 		},
-		"browserslist": {
-			"version": "2.11.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-			"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
-			"dev": true,
-			"requires": {
-				"caniuse-lite": "^1.0.30000792",
-				"electron-to-chromium": "^1.3.30"
-			}
-		},
 		"buffer-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
@@ -542,6 +613,30 @@
 				"unset-value": "^1.0.0"
 			}
 		},
+		"caller-callsite": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+			"integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+			"dev": true,
+			"requires": {
+				"callsites": "^2.0.0"
+			}
+		},
+		"caller-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+			"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+			"dev": true,
+			"requires": {
+				"caller-callsite": "^2.0.0"
+			}
+		},
+		"callsites": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+			"dev": true
+		},
 		"camelcase": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
@@ -565,24 +660,6 @@
 					"dev": true
 				}
 			}
-		},
-		"caniuse-api": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-2.0.0.tgz",
-			"integrity": "sha1-sd21pZZrFvSNxJmERNS7xsfZ2DQ=",
-			"dev": true,
-			"requires": {
-				"browserslist": "^2.0.0",
-				"caniuse-lite": "^1.0.0",
-				"lodash.memoize": "^4.1.2",
-				"lodash.uniq": "^4.5.0"
-			}
-		},
-		"caniuse-lite": {
-			"version": "1.0.30000918",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000918.tgz",
-			"integrity": "sha512-CAZ9QXGViBvhHnmIHhsTPSWFBujDaelKnUj7wwImbyQRxmXynYqKGi3UaZTSz9MoVh+1EVxOS/DFIkrJYgR3aw==",
-			"dev": true
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -693,6 +770,17 @@
 				}
 			}
 		},
+		"coa": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
+			"integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
+			"dev": true,
+			"requires": {
+				"@types/q": "^1.5.1",
+				"chalk": "^2.4.1",
+				"q": "^1.1.2"
+			}
+		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -720,25 +808,6 @@
 				"object-visit": "^1.0.0"
 			}
 		},
-		"color": {
-			"version": "0.11.4",
-			"resolved": "http://registry.npmjs.org/color/-/color-0.11.4.tgz",
-			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-			"dev": true,
-			"requires": {
-				"clone": "^1.0.2",
-				"color-convert": "^1.3.0",
-				"color-string": "^0.3.0"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-					"dev": true
-				}
-			}
-		},
 		"color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -753,15 +822,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
-		},
-		"color-string": {
-			"version": "0.3.0",
-			"resolved": "http://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-			"dev": true,
-			"requires": {
-				"color-name": "^1.0.0"
-			}
 		},
 		"color-support": {
 			"version": "1.1.3",
@@ -856,12 +916,6 @@
 				"is-plain-object": "^2.0.1"
 			}
 		},
-		"core-js": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
-			"integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw==",
-			"dev": true
-		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -902,39 +956,98 @@
 				"which": "^1.2.9"
 			}
 		},
-		"css-color-function": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/css-color-function/-/css-color-function-1.3.3.tgz",
-			"integrity": "sha1-jtJMLAIFBzM5+voAS8jBQfzLKC4=",
+		"css-color-names": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+			"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
+			"dev": true
+		},
+		"css-declaration-sorter": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
+			"integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
 			"dev": true,
 			"requires": {
-				"balanced-match": "0.1.0",
-				"color": "^0.11.0",
-				"debug": "^3.1.0",
-				"rgb": "~0.1.0"
+				"postcss": "^7.0.1",
+				"timsort": "^0.3.0"
 			},
 			"dependencies": {
-				"balanced-match": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
-					"integrity": "sha1-tQS9BYabOSWd0MXvw12EMXbczEo=",
-					"dev": true
-				},
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
 					}
 				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
 				}
+			}
+		},
+		"css-select": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
+			"integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
+			"dev": true,
+			"requires": {
+				"boolbase": "^1.0.0",
+				"css-what": "^2.1.2",
+				"domutils": "^1.7.0",
+				"nth-check": "^1.0.2"
+			}
+		},
+		"css-select-base-adapter": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
+			"integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
+			"dev": true
+		},
+		"css-tree": {
+			"version": "1.0.0-alpha.28",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
+			"integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
+			"dev": true,
+			"requires": {
+				"mdn-data": "~1.1.0",
+				"source-map": "^0.5.3"
 			}
 		},
 		"css-unit-converter": {
@@ -942,6 +1055,327 @@
 			"resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
 			"integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
 			"dev": true
+		},
+		"css-url-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
+			"integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w=",
+			"dev": true
+		},
+		"css-what": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+			"dev": true
+		},
+		"cssesc": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+			"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
+			"dev": true
+		},
+		"cssnano": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.10.tgz",
+			"integrity": "sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==",
+			"dev": true,
+			"requires": {
+				"cosmiconfig": "^5.0.0",
+				"cssnano-preset-default": "^4.0.7",
+				"is-resolvable": "^1.0.0",
+				"postcss": "^7.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"cosmiconfig": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
+					"integrity": "sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==",
+					"dev": true,
+					"requires": {
+						"import-fresh": "^2.0.0",
+						"is-directory": "^0.3.1",
+						"js-yaml": "^3.13.0",
+						"parse-json": "^4.0.0"
+					}
+				},
+				"js-yaml": {
+					"version": "3.13.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"cssnano-preset-default": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
+			"integrity": "sha512-x0YHHx2h6p0fCl1zY9L9roD7rnlltugGu7zXSKQx6k2rYw0Hi3IqxcoAGF7u9Q5w1nt7vK0ulxV8Lo+EvllGsA==",
+			"dev": true,
+			"requires": {
+				"css-declaration-sorter": "^4.0.1",
+				"cssnano-util-raw-cache": "^4.0.1",
+				"postcss": "^7.0.0",
+				"postcss-calc": "^7.0.1",
+				"postcss-colormin": "^4.0.3",
+				"postcss-convert-values": "^4.0.1",
+				"postcss-discard-comments": "^4.0.2",
+				"postcss-discard-duplicates": "^4.0.2",
+				"postcss-discard-empty": "^4.0.1",
+				"postcss-discard-overridden": "^4.0.1",
+				"postcss-merge-longhand": "^4.0.11",
+				"postcss-merge-rules": "^4.0.3",
+				"postcss-minify-font-values": "^4.0.2",
+				"postcss-minify-gradients": "^4.0.2",
+				"postcss-minify-params": "^4.0.2",
+				"postcss-minify-selectors": "^4.0.2",
+				"postcss-normalize-charset": "^4.0.1",
+				"postcss-normalize-display-values": "^4.0.2",
+				"postcss-normalize-positions": "^4.0.2",
+				"postcss-normalize-repeat-style": "^4.0.2",
+				"postcss-normalize-string": "^4.0.2",
+				"postcss-normalize-timing-functions": "^4.0.2",
+				"postcss-normalize-unicode": "^4.0.1",
+				"postcss-normalize-url": "^4.0.1",
+				"postcss-normalize-whitespace": "^4.0.2",
+				"postcss-ordered-values": "^4.1.2",
+				"postcss-reduce-initial": "^4.0.3",
+				"postcss-reduce-transforms": "^4.0.2",
+				"postcss-svgo": "^4.0.2",
+				"postcss-unique-selectors": "^4.0.1"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"postcss-calc": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.1.tgz",
+					"integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
+					"dev": true,
+					"requires": {
+						"css-unit-converter": "^1.1.1",
+						"postcss": "^7.0.5",
+						"postcss-selector-parser": "^5.0.0-rc.4",
+						"postcss-value-parser": "^3.3.1"
+					}
+				},
+				"postcss-selector-parser": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+					"dev": true,
+					"requires": {
+						"cssesc": "^2.0.0",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"cssnano-util-get-arguments": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
+			"integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8=",
+			"dev": true
+		},
+		"cssnano-util-get-match": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
+			"integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0=",
+			"dev": true
+		},
+		"cssnano-util-raw-cache": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
+			"integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"cssnano-util-same-parent": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz",
+			"integrity": "sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q==",
+			"dev": true
+		},
+		"csso": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
+			"integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
+			"dev": true,
+			"requires": {
+				"css-tree": "1.0.0-alpha.29"
+			},
+			"dependencies": {
+				"css-tree": {
+					"version": "1.0.0-alpha.29",
+					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
+					"integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
+					"dev": true,
+					"requires": {
+						"mdn-data": "~1.1.0",
+						"source-map": "^0.5.3"
+					}
+				}
+			}
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
@@ -1082,6 +1516,41 @@
 			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
 			"dev": true
 		},
+		"dom-serializer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+			"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+			"dev": true,
+			"requires": {
+				"domelementtype": "^1.3.0",
+				"entities": "^1.1.1"
+			}
+		},
+		"domelementtype": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+			"dev": true
+		},
+		"domutils": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+			"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+			"dev": true,
+			"requires": {
+				"dom-serializer": "0",
+				"domelementtype": "1"
+			}
+		},
+		"dot-prop": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+			"dev": true,
+			"requires": {
+				"is-obj": "^1.0.0"
+			}
+		},
 		"duplexify": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
@@ -1114,12 +1583,6 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
-		"electron-to-chromium": {
-			"version": "1.3.90",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.90.tgz",
-			"integrity": "sha512-IjJZKRhFbWSOX1w0sdIXgp4CMRguu6UYcTckyFF/Gjtemsu/25eZ+RXwFlV+UWcIueHyQA1UnRJxocTpH5NdGA==",
-			"dev": true
-		},
 		"end-of-stream": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -1129,6 +1592,12 @@
 				"once": "^1.4.0"
 			}
 		},
+		"entities": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+			"dev": true
+		},
 		"error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1136,6 +1605,31 @@
 			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+			"dev": true,
+			"requires": {
+				"es-to-primitive": "^1.2.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-keys": "^1.0.12"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
 			}
 		},
 		"es5-ext": {
@@ -1433,12 +1927,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
 			"integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=",
-			"dev": true
-		},
-		"flatten": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
-			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
 			"dev": true
 		},
 		"flush-write-stream": {
@@ -2478,6 +2966,15 @@
 				"har-schema": "^2.0.0"
 			}
 		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
 		"has-ansi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -2537,6 +3034,12 @@
 				}
 			}
 		},
+		"hex-color-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
+			"integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
+			"dev": true
+		},
 		"homedir-polyfill": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
@@ -2550,6 +3053,24 @@
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
 			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+			"dev": true
+		},
+		"hsl-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
+			"integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
+			"dev": true
+		},
+		"hsla-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
+			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
+			"dev": true
+		},
+		"html-comment-regex": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
+			"integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==",
 			"dev": true
 		},
 		"http-signature": {
@@ -2570,6 +3091,16 @@
 			"dev": true,
 			"requires": {
 				"import-from": "^2.1.0"
+			}
+		},
+		"import-fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+			"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+			"dev": true,
+			"requires": {
+				"caller-path": "^2.0.0",
+				"resolve-from": "^3.0.0"
 			}
 		},
 		"import-from": {
@@ -2646,6 +3177,12 @@
 				"is-windows": "^1.0.1"
 			}
 		},
+		"is-absolute-url": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+			"integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
+			"dev": true
+		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -2696,6 +3233,26 @@
 				"builtin-modules": "^1.0.0"
 			}
 		},
+		"is-callable": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+			"dev": true
+		},
+		"is-color-stop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
+			"integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
+			"dev": true,
+			"requires": {
+				"css-color-names": "^0.0.4",
+				"hex-color-regex": "^1.1.0",
+				"hsl-regex": "^1.0.0",
+				"hsla-regex": "^1.0.0",
+				"rgb-regex": "^1.0.1",
+				"rgba-regex": "^1.0.0"
+			}
+		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -2715,6 +3272,12 @@
 					}
 				}
 			}
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -2806,6 +3369,12 @@
 				}
 			}
 		},
+		"is-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+			"dev": true
+		},
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -2815,6 +3384,15 @@
 				"isobject": "^3.0.1"
 			}
 		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.1"
+			}
+		},
 		"is-relative": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
@@ -2822,6 +3400,30 @@
 			"dev": true,
 			"requires": {
 				"is-unc-path": "^1.0.0"
+			}
+		},
+		"is-resolvable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"dev": true
+		},
+		"is-svg": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
+			"integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
+			"dev": true,
+			"requires": {
+				"html-comment-regex": "^1.1.0"
+			}
+		},
+		"is-symbol": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.0"
 			}
 		},
 		"is-typedarray": {
@@ -2867,12 +3469,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
-		},
-		"isnumeric": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/isnumeric/-/isnumeric-0.2.0.tgz",
-			"integrity": "sha1-ojR7o2DeGeM9D/1ZD933dVy/LmQ=",
 			"dev": true
 		},
 		"isobject": {
@@ -3049,12 +3645,6 @@
 			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
 			"dev": true
 		},
-		"lodash._reinterpolate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-			"dev": true
-		},
 		"lodash.assign": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
@@ -3084,25 +3674,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
 			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
 			"dev": true
-		},
-		"lodash.template": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-			"dev": true,
-			"requires": {
-				"lodash._reinterpolate": "~3.0.0",
-				"lodash.templatesettings": "^4.0.0"
-			}
-		},
-		"lodash.templatesettings": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
-			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-			"dev": true,
-			"requires": {
-				"lodash._reinterpolate": "~3.0.0"
-			}
 		},
 		"lodash.uniq": {
 			"version": "4.5.0",
@@ -3172,10 +3743,10 @@
 				"stack-trace": "0.0.10"
 			}
 		},
-		"math-expression-evaluator": {
-			"version": "1.2.17",
-			"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
-			"integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
+		"mdn-data": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+			"integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
 			"dev": true
 		},
 		"meow": {
@@ -3356,6 +3927,15 @@
 				}
 			}
 		},
+		"node-releases": {
+			"version": "1.1.17",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.17.tgz",
+			"integrity": "sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==",
+			"dev": true,
+			"requires": {
+				"semver": "^5.3.0"
+			}
+		},
 		"node-sass": {
 			"version": "4.11.0",
 			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
@@ -3446,6 +4026,12 @@
 			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
 			"dev": true
 		},
+		"normalize-url": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+			"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+			"dev": true
+		},
 		"now-and-later": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
@@ -3465,6 +4051,15 @@
 				"console-control-strings": "~1.1.0",
 				"gauge": "~2.7.3",
 				"set-blocking": "~2.0.0"
+			}
+		},
+		"nth-check": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+			"dev": true,
+			"requires": {
+				"boolbase": "~1.0.0"
 			}
 		},
 		"ntheme": {
@@ -3572,6 +4167,16 @@
 				"isobject": "^3.0.0"
 			}
 		},
+		"object.getownpropertydescriptors": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
+			}
+		},
 		"object.map": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
@@ -3601,6 +4206,18 @@
 				"make-iterator": "^1.0.0"
 			}
 		},
+		"object.values": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+			"integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.12.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3"
+			}
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3609,12 +4226,6 @@
 			"requires": {
 				"wrappy": "1"
 			}
-		},
-		"onecolor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/onecolor/-/onecolor-3.1.0.tgz",
-			"integrity": "sha512-YZSypViXzu3ul5LMu/m6XjJ9ol8qAy9S2VjHl5E6UlhUH1KGKWabyEJifn0Jjpw23bYDzC2ucKMPGiH5kfwSGQ==",
-			"dev": true
 		},
 		"ordered-read-streams": {
 			"version": "1.0.1",
@@ -3774,27 +4385,6 @@
 				"pinkie": "^2.0.0"
 			}
 		},
-		"pixrem": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pixrem/-/pixrem-4.0.1.tgz",
-			"integrity": "sha1-LaSh3m7EQjxfw3lOkwuB1EkOxoY=",
-			"dev": true,
-			"requires": {
-				"browserslist": "^2.0.0",
-				"postcss": "^6.0.0",
-				"reduce-css-calc": "^1.2.7"
-			}
-		},
-		"pleeease-filters": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/pleeease-filters/-/pleeease-filters-4.0.0.tgz",
-			"integrity": "sha1-ZjKy+wVkjSdY2GU4T7zteeHMrsc=",
-			"dev": true,
-			"requires": {
-				"onecolor": "^3.0.4",
-				"postcss": "^6.0.1"
-			}
-		},
 		"plugin-error": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
@@ -3858,123 +4448,62 @@
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
 			"dev": true
 		},
-		"postcss": {
-			"version": "6.0.23",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-			"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+		"postcss-colormin": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
+			"integrity": "sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.4.1",
-				"source-map": "^0.6.1",
-				"supports-color": "^5.4.0"
+				"browserslist": "^4.0.0",
+				"color": "^3.0.0",
+				"has": "^1.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
 			},
 			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
-		"postcss-apply": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/postcss-apply/-/postcss-apply-0.8.0.tgz",
-			"integrity": "sha1-FOVEu7XLbxweBIhXll15rgZrE0M=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.23.0",
-				"balanced-match": "^0.4.2",
-				"postcss": "^6.0.0"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-					"dev": true
-				}
-			}
-		},
-		"postcss-attribute-case-insensitive": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-2.0.0.tgz",
-			"integrity": "sha1-lNxCLI+QmX8WvTOjZUu77AhJY7Q=",
-			"dev": true,
-			"requires": {
-				"postcss": "^6.0.0",
-				"postcss-selector-parser": "^2.2.3"
-			}
-		},
-		"postcss-calc": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-6.0.2.tgz",
-			"integrity": "sha512-fiznXjEN5T42Qm7qqMCVJXS3roaj9r4xsSi+meaBVe7CJBl8t/QLOXu02Z2E6oWAMWIvCuF6JrvzFekmVEbOKA==",
-			"dev": true,
-			"requires": {
-				"css-unit-converter": "^1.1.1",
-				"postcss": "^7.0.2",
-				"postcss-selector-parser": "^2.2.2",
-				"reduce-css-calc": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.6",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
-					"integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
+				"browserslist": {
+					"version": "4.5.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.6.tgz",
+					"integrity": "sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.5.0"
+						"caniuse-lite": "^1.0.30000963",
+						"electron-to-chromium": "^1.3.127",
+						"node-releases": "^1.1.17"
 					}
 				},
-				"reduce-css-calc": {
-					"version": "2.1.5",
-					"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.5.tgz",
-					"integrity": "sha512-AybiBU03FKbjYzyvJvwkJZY6NLN+80Ufc2EqEs+41yQH+8wqBEslD6eGiS0oIeq5TNLA5PrhBeYHXWdn8gtW7A==",
+				"caniuse-lite": {
+					"version": "1.0.30000966",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000966.tgz",
+					"integrity": "sha512-qqLQ/uYrpZmFhPY96VuBkMEo8NhVFBZ9y/Bh+KnvGzGJ5I8hvpIaWlF2pw5gqe4PLAL+ZjsPgMOvoXSpX21Keg==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
-						"css-unit-converter": "^1.1.1",
-						"postcss-value-parser": "^3.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
 					}
 				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
-		"postcss-color-function": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-color-function/-/postcss-color-function-4.0.1.tgz",
-			"integrity": "sha1-QCs/LOvD9pR+YY+2vjZU++zvZEQ=",
-			"dev": true,
-			"requires": {
-				"css-color-function": "~1.3.3",
-				"postcss": "^6.0.1",
-				"postcss-message-helpers": "^2.0.0",
-				"postcss-value-parser": "^3.3.0"
-			}
-		},
-		"postcss-color-gray": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-4.1.0.tgz",
-			"integrity": "sha512-L4iLKQLdqChz6ZOgGb6dRxkBNw78JFYcJmBz1orHpZoeLtuhDDGegRtX9gSyfoCIM7rWZ3VNOyiqqvk83BEN+w==",
-			"dev": true,
-			"requires": {
-				"color": "^2.0.1",
-				"postcss": "^6.0.14",
-				"postcss-message-helpers": "^2.0.0",
-				"reduce-function-call": "^1.0.2"
-			},
-			"dependencies": {
 				"color": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
-					"integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/color/-/color-3.1.1.tgz",
+					"integrity": "sha512-PvUltIXRjehRKPSy89VnDWFKY58xyhTLyxIg21vwQBI6qLwZNPmC8k3C1uytIgFKEpOIzN4y32iPm8231zFHIg==",
 					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.1",
@@ -3990,222 +4519,335 @@
 						"color-name": "^1.0.0",
 						"simple-swizzle": "^0.2.2"
 					}
-				}
-			}
-		},
-		"postcss-color-hex-alpha": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-3.0.0.tgz",
-			"integrity": "sha1-HlPmyKyyN5Vej9CLfs2xuLgwn5U=",
-			"dev": true,
-			"requires": {
-				"color": "^1.0.3",
-				"postcss": "^6.0.1",
-				"postcss-message-helpers": "^2.0.0"
-			},
-			"dependencies": {
-				"color": {
-					"version": "1.0.3",
-					"resolved": "http://registry.npmjs.org/color/-/color-1.0.3.tgz",
-					"integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
+				},
+				"electron-to-chromium": {
+					"version": "1.3.131",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.131.tgz",
+					"integrity": "sha512-NSO4jLeyGLWrT4mzzfYX8vt1MYCoMI5LxSYAjt0H9+LF/14JyiKJSyyjA6AJTxflZlEM5v3QU33F0ohbPMCAPg==",
+					"dev": true
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.8.2",
-						"color-string": "^1.4.0"
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
 					}
 				},
-				"color-string": {
-					"version": "1.5.3",
-					"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
-					"integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
-					"dev": true,
-					"requires": {
-						"color-name": "^1.0.0",
-						"simple-swizzle": "^0.2.2"
-					}
-				}
-			}
-		},
-		"postcss-color-hsl": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-color-hsl/-/postcss-color-hsl-2.0.0.tgz",
-			"integrity": "sha1-EnA2ZvoxBDDj8wpFTawThjF9WEQ=",
-			"dev": true,
-			"requires": {
-				"postcss": "^6.0.1",
-				"postcss-value-parser": "^3.3.0",
-				"units-css": "^0.4.0"
-			}
-		},
-		"postcss-color-hwb": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-color-hwb/-/postcss-color-hwb-3.0.0.tgz",
-			"integrity": "sha1-NAKxnvTYSXVAwftQcr6YY8qVVx4=",
-			"dev": true,
-			"requires": {
-				"color": "^1.0.3",
-				"postcss": "^6.0.1",
-				"postcss-message-helpers": "^2.0.0",
-				"reduce-function-call": "^1.0.2"
-			},
-			"dependencies": {
-				"color": {
-					"version": "1.0.3",
-					"resolved": "http://registry.npmjs.org/color/-/color-1.0.3.tgz",
-					"integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.8.2",
-						"color-string": "^1.4.0"
-					}
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				},
-				"color-string": {
-					"version": "1.5.3",
-					"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
-					"integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
-						"color-name": "^1.0.0",
-						"simple-swizzle": "^0.2.2"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
 		},
-		"postcss-color-rebeccapurple": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-3.1.0.tgz",
-			"integrity": "sha512-212hJUk9uSsbwO5ECqVjmh/iLsmiVL1xy9ce9TVf+X3cK/ZlUIlaMdoxje/YpsL9cmUH3I7io+/G2LyWx5rg1g==",
-			"dev": true,
-			"requires": {
-				"postcss": "^6.0.22",
-				"postcss-values-parser": "^1.5.0"
-			}
-		},
-		"postcss-color-rgb": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-color-rgb/-/postcss-color-rgb-2.0.0.tgz",
-			"integrity": "sha1-FFOcinExSUtILg3RzCZf9lFLUmM=",
-			"dev": true,
-			"requires": {
-				"postcss": "^6.0.1",
-				"postcss-value-parser": "^3.3.0"
-			}
-		},
-		"postcss-color-rgba-fallback": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-color-rgba-fallback/-/postcss-color-rgba-fallback-3.0.0.tgz",
-			"integrity": "sha1-N9XJNToHoJJwkSqCYGu0Kg1wLAQ=",
-			"dev": true,
-			"requires": {
-				"postcss": "^6.0.6",
-				"postcss-value-parser": "^3.3.0",
-				"rgb-hex": "^2.1.0"
-			}
-		},
-		"postcss-cssnext": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-cssnext/-/postcss-cssnext-3.1.0.tgz",
-			"integrity": "sha512-awPDhI4OKetcHCr560iVCoDuP6e/vn0r6EAqdWPpAavJMvkBSZ6kDpSN4b3mB3Ti57hQMunHHM8Wvx9PeuYXtA==",
-			"dev": true,
-			"requires": {
-				"autoprefixer": "^7.1.1",
-				"caniuse-api": "^2.0.0",
-				"chalk": "^2.0.1",
-				"pixrem": "^4.0.0",
-				"pleeease-filters": "^4.0.0",
-				"postcss": "^6.0.5",
-				"postcss-apply": "^0.8.0",
-				"postcss-attribute-case-insensitive": "^2.0.0",
-				"postcss-calc": "^6.0.0",
-				"postcss-color-function": "^4.0.0",
-				"postcss-color-gray": "^4.0.0",
-				"postcss-color-hex-alpha": "^3.0.0",
-				"postcss-color-hsl": "^2.0.0",
-				"postcss-color-hwb": "^3.0.0",
-				"postcss-color-rebeccapurple": "^3.0.0",
-				"postcss-color-rgb": "^2.0.0",
-				"postcss-color-rgba-fallback": "^3.0.0",
-				"postcss-custom-media": "^6.0.0",
-				"postcss-custom-properties": "^6.1.0",
-				"postcss-custom-selectors": "^4.0.1",
-				"postcss-font-family-system-ui": "^3.0.0",
-				"postcss-font-variant": "^3.0.0",
-				"postcss-image-set-polyfill": "^0.3.5",
-				"postcss-initial": "^2.0.0",
-				"postcss-media-minmax": "^3.0.0",
-				"postcss-nesting": "^4.0.1",
-				"postcss-pseudo-class-any-link": "^4.0.0",
-				"postcss-pseudoelements": "^5.0.0",
-				"postcss-replace-overflow-wrap": "^2.0.0",
-				"postcss-selector-matches": "^3.0.1",
-				"postcss-selector-not": "^3.0.1"
-			}
-		},
-		"postcss-custom-media": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-6.0.0.tgz",
-			"integrity": "sha1-vlMnhBEOyylQRPtTlaGABushpzc=",
-			"dev": true,
-			"requires": {
-				"postcss": "^6.0.1"
-			}
-		},
-		"postcss-custom-properties": {
-			"version": "6.3.1",
-			"resolved": "http://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-6.3.1.tgz",
-			"integrity": "sha512-zoiwn4sCiUFbr4KcgcNZLFkR6gVQom647L+z1p/KBVHZ1OYwT87apnS42atJtx6XlX2yI7N5fjXbFixShQO2QQ==",
-			"dev": true,
-			"requires": {
-				"balanced-match": "^1.0.0",
-				"postcss": "^6.0.18"
-			}
-		},
-		"postcss-custom-selectors": {
+		"postcss-convert-values": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-4.0.1.tgz",
-			"integrity": "sha1-eBOC+UxS5yfvXKR3bqKt9JphE4I=",
+			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
+			"integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
 			"dev": true,
 			"requires": {
-				"postcss": "^6.0.1",
-				"postcss-selector-matches": "^3.0.0"
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
-		"postcss-font-family-system-ui": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-font-family-system-ui/-/postcss-font-family-system-ui-3.0.0.tgz",
-			"integrity": "sha512-58G/hTxMSSKlIRpcPUjlyo6hV2MEzvcVO2m4L/T7Bb2fJTG4DYYfQjQeRvuimKQh1V1sOzCIz99g+H2aFNtlQw==",
+		"postcss-discard-comments": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
+			"integrity": "sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==",
 			"dev": true,
 			"requires": {
-				"postcss": "^6.0"
+				"postcss": "^7.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
-		"postcss-font-variant": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-3.0.0.tgz",
-			"integrity": "sha1-CMzIj2BQuoLtjvLMdsDGprQfGD4=",
+		"postcss-discard-duplicates": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
+			"integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
 			"dev": true,
 			"requires": {
-				"postcss": "^6.0.1"
+				"postcss": "^7.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
-		"postcss-image-set-polyfill": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/postcss-image-set-polyfill/-/postcss-image-set-polyfill-0.3.5.tgz",
-			"integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
+		"postcss-discard-empty": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
+			"integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
 			"dev": true,
 			"requires": {
-				"postcss": "^6.0.1",
-				"postcss-media-query-parser": "^0.2.3"
+				"postcss": "^7.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
-		"postcss-initial": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-2.0.0.tgz",
-			"integrity": "sha1-cnFfczbgu3k1HZnuZcSiU6hEG6Q=",
+		"postcss-discard-overridden": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
+			"integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
 			"dev": true,
 			"requires": {
-				"lodash.template": "^4.2.4",
-				"postcss": "^6.0.1"
+				"postcss": "^7.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"postcss-load-config": {
@@ -4218,109 +4860,1373 @@
 				"import-cwd": "^2.0.0"
 			}
 		},
-		"postcss-media-minmax": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-3.0.0.tgz",
-			"integrity": "sha1-Z1JWA3pD70C8Twdgv9BtTcadSNI=",
+		"postcss-merge-longhand": {
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
+			"integrity": "sha512-alx/zmoeXvJjp7L4mxEMjh8lxVlDFX1gqWHzaaQewwMZiVhLo42TEClKaeHbRf6J7j82ZOdTJ808RtN0ZOZwvw==",
 			"dev": true,
 			"requires": {
-				"postcss": "^6.0.1"
-			}
-		},
-		"postcss-media-query-parser": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
-			"integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
-			"dev": true
-		},
-		"postcss-message-helpers": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
-			"integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
-			"dev": true
-		},
-		"postcss-nesting": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-4.2.1.tgz",
-			"integrity": "sha512-IkyWXICwagCnlaviRexi7qOdwPw3+xVVjgFfGsxmztvRVaNxAlrypOIKqDE5mxY+BVxnId1rnUKBRQoNE2VDaA==",
-			"dev": true,
-			"requires": {
-				"postcss": "^6.0.11"
-			}
-		},
-		"postcss-pseudo-class-any-link": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-4.0.0.tgz",
-			"integrity": "sha1-kVKgYT00UHIFE+iJKFS65C0O5o4=",
-			"dev": true,
-			"requires": {
-				"postcss": "^6.0.1",
-				"postcss-selector-parser": "^2.2.3"
-			}
-		},
-		"postcss-pseudoelements": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-pseudoelements/-/postcss-pseudoelements-5.0.0.tgz",
-			"integrity": "sha1-7vGU6NUkZFylIKlJ6V5RjoEkAss=",
-			"dev": true,
-			"requires": {
-				"postcss": "^6.0.0"
-			}
-		},
-		"postcss-replace-overflow-wrap": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-2.0.0.tgz",
-			"integrity": "sha1-eU22+qVPjbEAhUOSqTr0V2i04ls=",
-			"dev": true,
-			"requires": {
-				"postcss": "^6.0.1"
-			}
-		},
-		"postcss-selector-matches": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-3.0.1.tgz",
-			"integrity": "sha1-5WNAEeE5UIgYYbvdWMLQER/8lqs=",
-			"dev": true,
-			"requires": {
-				"balanced-match": "^0.4.2",
-				"postcss": "^6.0.1"
+				"css-color-names": "0.0.4",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0",
+				"stylehacks": "^4.0.0"
 			},
 			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
 				}
 			}
 		},
-		"postcss-selector-not": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-3.0.1.tgz",
-			"integrity": "sha1-Lk2y8JZTNsAefOx9tsYN/3ZzNdk=",
+		"postcss-merge-rules": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
+			"integrity": "sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==",
 			"dev": true,
 			"requires": {
-				"balanced-match": "^0.4.2",
-				"postcss": "^6.0.1"
+				"browserslist": "^4.0.0",
+				"caniuse-api": "^3.0.0",
+				"cssnano-util-same-parent": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-selector-parser": "^3.0.0",
+				"vendors": "^1.0.0"
 			},
 			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+				"browserslist": {
+					"version": "4.5.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.6.tgz",
+					"integrity": "sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30000963",
+						"electron-to-chromium": "^1.3.127",
+						"node-releases": "^1.1.17"
+					}
+				},
+				"caniuse-api": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+					"integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+					"dev": true,
+					"requires": {
+						"browserslist": "^4.0.0",
+						"caniuse-lite": "^1.0.0",
+						"lodash.memoize": "^4.1.2",
+						"lodash.uniq": "^4.5.0"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30000966",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000966.tgz",
+					"integrity": "sha512-qqLQ/uYrpZmFhPY96VuBkMEo8NhVFBZ9y/Bh+KnvGzGJ5I8hvpIaWlF2pw5gqe4PLAL+ZjsPgMOvoXSpX21Keg==",
 					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"electron-to-chromium": {
+					"version": "1.3.131",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.131.tgz",
+					"integrity": "sha512-NSO4jLeyGLWrT4mzzfYX8vt1MYCoMI5LxSYAjt0H9+LF/14JyiKJSyyjA6AJTxflZlEM5v3QU33F0ohbPMCAPg==",
+					"dev": true
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"postcss-selector-parser": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"dev": true,
+					"requires": {
+						"dot-prop": "^4.1.1",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
 				}
 			}
 		},
-		"postcss-selector-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+		"postcss-minify-font-values": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
+			"integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
 			"dev": true,
 			"requires": {
-				"flatten": "^1.0.2",
-				"indexes-of": "^1.0.1",
-				"uniq": "^1.0.1"
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-minify-gradients": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
+			"integrity": "sha512-qKPfwlONdcf/AndP1U8SJ/uzIJtowHlMaSioKzebAXSG4iJthlWC9iSWznQcX4f66gIWX44RSA841HTHj3wK+Q==",
+			"dev": true,
+			"requires": {
+				"cssnano-util-get-arguments": "^4.0.0",
+				"is-color-stop": "^1.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-minify-params": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
+			"integrity": "sha512-G7eWyzEx0xL4/wiBBJxJOz48zAKV2WG3iZOqVhPet/9geefm/Px5uo1fzlHu+DOjT+m0Mmiz3jkQzVHe6wxAWg==",
+			"dev": true,
+			"requires": {
+				"alphanum-sort": "^1.0.0",
+				"browserslist": "^4.0.0",
+				"cssnano-util-get-arguments": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0",
+				"uniqs": "^2.0.0"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "4.5.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.6.tgz",
+					"integrity": "sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30000963",
+						"electron-to-chromium": "^1.3.127",
+						"node-releases": "^1.1.17"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30000966",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000966.tgz",
+					"integrity": "sha512-qqLQ/uYrpZmFhPY96VuBkMEo8NhVFBZ9y/Bh+KnvGzGJ5I8hvpIaWlF2pw5gqe4PLAL+ZjsPgMOvoXSpX21Keg==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"electron-to-chromium": {
+					"version": "1.3.131",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.131.tgz",
+					"integrity": "sha512-NSO4jLeyGLWrT4mzzfYX8vt1MYCoMI5LxSYAjt0H9+LF/14JyiKJSyyjA6AJTxflZlEM5v3QU33F0ohbPMCAPg==",
+					"dev": true
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-minify-selectors": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
+			"integrity": "sha512-D5S1iViljXBj9kflQo4YutWnJmwm8VvIsU1GeXJGiG9j8CIg9zs4voPMdQDUmIxetUOh60VilsNzCiAFTOqu3g==",
+			"dev": true,
+			"requires": {
+				"alphanum-sort": "^1.0.0",
+				"has": "^1.0.0",
+				"postcss": "^7.0.0",
+				"postcss-selector-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"postcss-selector-parser": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"dev": true,
+					"requires": {
+						"dot-prop": "^4.1.1",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-normalize-charset": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
+			"integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-normalize-display-values": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
+			"integrity": "sha512-3F2jcsaMW7+VtRMAqf/3m4cPFhPD3EFRgNs18u+k3lTJJlVe7d0YPO+bnwqo2xg8YiRpDXJI2u8A0wqJxMsQuQ==",
+			"dev": true,
+			"requires": {
+				"cssnano-util-get-match": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-normalize-positions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
+			"integrity": "sha512-Dlf3/9AxpxE+NF1fJxYDeggi5WwV35MXGFnnoccP/9qDtFrTArZ0D0R+iKcg5WsUd8nUYMIl8yXDCtcrT8JrdA==",
+			"dev": true,
+			"requires": {
+				"cssnano-util-get-arguments": "^4.0.0",
+				"has": "^1.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-normalize-repeat-style": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
+			"integrity": "sha512-qvigdYYMpSuoFs3Is/f5nHdRLJN/ITA7huIoCyqqENJe9PvPmLhNLMu7QTjPdtnVf6OcYYO5SHonx4+fbJE1+Q==",
+			"dev": true,
+			"requires": {
+				"cssnano-util-get-arguments": "^4.0.0",
+				"cssnano-util-get-match": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-normalize-string": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
+			"integrity": "sha512-RrERod97Dnwqq49WNz8qo66ps0swYZDSb6rM57kN2J+aoyEAJfZ6bMx0sx/F9TIEX0xthPGCmeyiam/jXif0eA==",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-normalize-timing-functions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
+			"integrity": "sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==",
+			"dev": true,
+			"requires": {
+				"cssnano-util-get-match": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-normalize-unicode": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
+			"integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "4.5.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.6.tgz",
+					"integrity": "sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30000963",
+						"electron-to-chromium": "^1.3.127",
+						"node-releases": "^1.1.17"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30000966",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000966.tgz",
+					"integrity": "sha512-qqLQ/uYrpZmFhPY96VuBkMEo8NhVFBZ9y/Bh+KnvGzGJ5I8hvpIaWlF2pw5gqe4PLAL+ZjsPgMOvoXSpX21Keg==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"electron-to-chromium": {
+					"version": "1.3.131",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.131.tgz",
+					"integrity": "sha512-NSO4jLeyGLWrT4mzzfYX8vt1MYCoMI5LxSYAjt0H9+LF/14JyiKJSyyjA6AJTxflZlEM5v3QU33F0ohbPMCAPg==",
+					"dev": true
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-normalize-url": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
+			"integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
+			"dev": true,
+			"requires": {
+				"is-absolute-url": "^2.0.0",
+				"normalize-url": "^3.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-normalize-whitespace": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
+			"integrity": "sha512-tO8QIgrsI3p95r8fyqKV+ufKlSHh9hMJqACqbv2XknufqEDhDvbguXGBBqxw9nsQoXWf0qOqppziKJKHMD4GtA==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-ordered-values": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
+			"integrity": "sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==",
+			"dev": true,
+			"requires": {
+				"cssnano-util-get-arguments": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-reduce-initial": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
+			"integrity": "sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.0.0",
+				"caniuse-api": "^3.0.0",
+				"has": "^1.0.0",
+				"postcss": "^7.0.0"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "4.5.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.6.tgz",
+					"integrity": "sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30000963",
+						"electron-to-chromium": "^1.3.127",
+						"node-releases": "^1.1.17"
+					}
+				},
+				"caniuse-api": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+					"integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+					"dev": true,
+					"requires": {
+						"browserslist": "^4.0.0",
+						"caniuse-lite": "^1.0.0",
+						"lodash.memoize": "^4.1.2",
+						"lodash.uniq": "^4.5.0"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30000966",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000966.tgz",
+					"integrity": "sha512-qqLQ/uYrpZmFhPY96VuBkMEo8NhVFBZ9y/Bh+KnvGzGJ5I8hvpIaWlF2pw5gqe4PLAL+ZjsPgMOvoXSpX21Keg==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"electron-to-chromium": {
+					"version": "1.3.131",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.131.tgz",
+					"integrity": "sha512-NSO4jLeyGLWrT4mzzfYX8vt1MYCoMI5LxSYAjt0H9+LF/14JyiKJSyyjA6AJTxflZlEM5v3QU33F0ohbPMCAPg==",
+					"dev": true
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-reduce-transforms": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
+			"integrity": "sha512-EEVig1Q2QJ4ELpJXMZR8Vt5DQx8/mo+dGWSR7vWXqcob2gQLyQGsionYcGKATXvQzMPn6DSN1vTN7yFximdIAg==",
+			"dev": true,
+			"requires": {
+				"cssnano-util-get-match": "^4.0.0",
+				"has": "^1.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-svgo": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
+			"integrity": "sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==",
+			"dev": true,
+			"requires": {
+				"is-svg": "^3.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0",
+				"svgo": "^1.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-unique-selectors": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
+			"integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
+			"dev": true,
+			"requires": {
+				"alphanum-sort": "^1.0.0",
+				"postcss": "^7.0.0",
+				"uniqs": "^2.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"postcss-value-parser": {
@@ -4328,17 +6234,6 @@
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
 			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
 			"dev": true
-		},
-		"postcss-values-parser": {
-			"version": "1.5.0",
-			"resolved": "http://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-1.5.0.tgz",
-			"integrity": "sha512-3M3p+2gMp0AH3da530TlX8kiO1nxdTnc3C6vr8dMxRLIlh8UYkz0/wcwptSXjhtx2Fr0TySI7a+BHDQ8NL7LaQ==",
-			"dev": true,
-			"requires": {
-				"flatten": "^1.0.2",
-				"indexes-of": "^1.0.1",
-				"uniq": "^1.0.1"
-			}
 		},
 		"pretty-hrtime": {
 			"version": "1.0.3",
@@ -4389,6 +6284,12 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true
+		},
+		"q": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
 			"dev": true
 		},
 		"qs": {
@@ -4470,48 +6371,6 @@
 				"indent-string": "^2.1.0",
 				"strip-indent": "^1.0.1"
 			}
-		},
-		"reduce-css-calc": {
-			"version": "1.3.0",
-			"resolved": "http://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
-			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
-			"dev": true,
-			"requires": {
-				"balanced-match": "^0.4.2",
-				"math-expression-evaluator": "^1.2.14",
-				"reduce-function-call": "^1.0.1"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-					"dev": true
-				}
-			}
-		},
-		"reduce-function-call": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
-			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
-			"dev": true,
-			"requires": {
-				"balanced-match": "^0.4.2"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-					"dev": true
-				}
-			}
-		},
-		"regenerator-runtime": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-			"dev": true
 		},
 		"regex-not": {
 			"version": "1.0.2",
@@ -4680,16 +6539,16 @@
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
 			"dev": true
 		},
-		"rgb": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/rgb/-/rgb-0.1.0.tgz",
-			"integrity": "sha1-vieykej+/+rBvZlylyG/pA/AN7U=",
+		"rgb-regex": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
+			"integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
 			"dev": true
 		},
-		"rgb-hex": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/rgb-hex/-/rgb-hex-2.1.0.tgz",
-			"integrity": "sha1-x3PF/iJoolV42SU5qCp6XOU77aY=",
+		"rgba-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
+			"integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
 			"dev": true
 		},
 		"rimraf": {
@@ -4733,6 +6592,12 @@
 				"scss-tokenizer": "^0.2.3",
 				"yargs": "^7.0.0"
 			}
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
 		},
 		"scss-tokenizer": {
 			"version": "0.2.3",
@@ -5040,6 +6905,12 @@
 				"tweetnacl": "~0.14.0"
 			}
 		},
+		"stable": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+			"dev": true
+		},
 		"stack-trace": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -5135,6 +7006,101 @@
 				"get-stdin": "^4.0.1"
 			}
 		},
+		"stylehacks": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
+			"integrity": "sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-selector-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "4.5.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.6.tgz",
+					"integrity": "sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30000963",
+						"electron-to-chromium": "^1.3.127",
+						"node-releases": "^1.1.17"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30000966",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000966.tgz",
+					"integrity": "sha512-qqLQ/uYrpZmFhPY96VuBkMEo8NhVFBZ9y/Bh+KnvGzGJ5I8hvpIaWlF2pw5gqe4PLAL+ZjsPgMOvoXSpX21Keg==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"electron-to-chromium": {
+					"version": "1.3.131",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.131.tgz",
+					"integrity": "sha512-NSO4jLeyGLWrT4mzzfYX8vt1MYCoMI5LxSYAjt0H9+LF/14JyiKJSyyjA6AJTxflZlEM5v3QU33F0ohbPMCAPg==",
+					"dev": true
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"postcss-selector-parser": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"dev": true,
+					"requires": {
+						"dot-prop": "^4.1.1",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
 		"supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -5152,6 +7118,40 @@
 			"requires": {
 				"es6-iterator": "^2.0.1",
 				"es6-symbol": "^3.1.1"
+			}
+		},
+		"svgo": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.2.tgz",
+			"integrity": "sha512-rAfulcwp2D9jjdGu+0CuqlrAUin6bBWrpoqXWwKDZZZJfXcUXQSxLJOFJCQCSA0x0pP2U0TxSlJu2ROq5Bq6qA==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.1",
+				"coa": "^2.0.2",
+				"css-select": "^2.0.0",
+				"css-select-base-adapter": "^0.1.1",
+				"css-tree": "1.0.0-alpha.28",
+				"css-url-regex": "^1.1.0",
+				"csso": "^3.5.1",
+				"js-yaml": "^3.13.1",
+				"mkdirp": "~0.5.1",
+				"object.values": "^1.1.0",
+				"sax": "~1.2.4",
+				"stable": "^0.1.8",
+				"unquote": "~1.1.1",
+				"util.promisify": "~1.0.0"
+			},
+			"dependencies": {
+				"js-yaml": {
+					"version": "3.13.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				}
 			}
 		},
 		"tar": {
@@ -5189,6 +7189,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
 			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+			"dev": true
+		},
+		"timsort": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
+			"integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
 			"dev": true
 		},
 		"to-absolute-glob": {
@@ -5376,6 +7382,12 @@
 			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
 			"dev": true
 		},
+		"uniqs": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+			"dev": true
+		},
 		"unique-stream": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
@@ -5386,15 +7398,11 @@
 				"through2-filter": "^2.0.0"
 			}
 		},
-		"units-css": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/units-css/-/units-css-0.4.0.tgz",
-			"integrity": "sha1-1iKGU6UZg9fBb/KPi53Dsf/tOgc=",
-			"dev": true,
-			"requires": {
-				"isnumeric": "^0.2.0",
-				"viewport-dimensions": "^0.2.0"
-			}
+		"unquote": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+			"integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
+			"dev": true
 		},
 		"unset-value": {
 			"version": "1.0.0",
@@ -5469,6 +7477,16 @@
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"dev": true
 		},
+		"util.promisify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"object.getownpropertydescriptors": "^2.0.3"
+			}
+		},
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -5500,6 +7518,12 @@
 			"integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
 			"dev": true
 		},
+		"vendors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
+			"integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ==",
+			"dev": true
+		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -5510,12 +7534,6 @@
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
 			}
-		},
-		"viewport-dimensions": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/viewport-dimensions/-/viewport-dimensions-0.2.0.tgz",
-			"integrity": "sha1-3nQHR9tTh/0XJfUXXpG6x2r982w=",
-			"dev": true
 		},
 		"vinyl": {
 			"version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,13 +20,14 @@
 	},
 	"homepage": "https://github.com/NetoECommerce/Skeletal",
 	"devDependencies": {
+		"autoprefixer": "^9.5.1",
+		"cssnano": "^4.1.10",
 		"gulp": "^4.0.0",
 		"gulp-concat": "^2.6.1",
 		"gulp-plumber": "^1.2.1",
 		"gulp-postcss": "^8.0.0",
 		"gulp-sass": "^4.0.2",
 		"ntheme": "^1.9.0",
-		"postcss-cssnext": "^3.1.0",
 		"simple-github-release": "git+https://github.com/brandonsheppard/simple-github-release.git"
 	},
 	"dependencies": {


### PR DESCRIPTION
Removed cssnext in favour for autoprefixer and cssnano.

Slimmed app.css by 90kb

Current app.css

<img width="266" alt="Screen Shot 2019-05-07 at 9 56 25 am" src="https://user-images.githubusercontent.com/13529653/57262782-ffd1b800-70b0-11e9-864e-c123d7e42063.png">

New app.css

<img width="270" alt="Screen Shot 2019-05-07 at 9 55 28 am" src="https://user-images.githubusercontent.com/13529653/57262786-019b7b80-70b1-11e9-90cf-be0242311be2.png">
