### PR TITLE
CAT-1007 updated invoice_body payment methods to be more robust

### DIFF
--- a/src/templates/cart/includes/invoice_body.template.html
+++ b/src/templates/cart/includes/invoice_body.template.html
@@ -118,7 +118,7 @@
 							<p class="mb-1">
 								[%if [@charge_type@] eq 'web' OR [@charge_type@] eq 'cc'%]<i class="fa fa-credit-card"></i> [%/if%]
 								[%if [@charge_type@] eq 'acc'%][@config:company_name@] [%/if%]
-								[@name@]
+								[%escape%][@name@][%/escape%]
 							</p>
 						[%/param%]
 						[%param *ifempty%]

--- a/src/templates/cart/includes/invoice_body.template.html
+++ b/src/templates/cart/includes/invoice_body.template.html
@@ -113,24 +113,13 @@
 			[%if [@^order_type@] ne 'quote'%]
 				<div class="col-12 col-sm-6">
 					<h4>Payment method</h4>
-					[%payment_methods id:'[@payment_method@]' ignore_balance:'1'%]
+					[%payment_methods id:'[@payment_method@]'%]
 						[%param *body%]
-							[%if [@name@] like 'American Express'%]<p class="mb-1"><i class="fa fa-credit-card"></i> American Express</p>[%/if%]
-							[%if [@name@] like 'Visa'%]<p class="mb-1"><i class="fa fa-credit-card"></i> Visa</p>[%/if%]
-							[%if [@name@] like 'Master Card' OR [@name@] like 'MasterCard'%]<p class="mb-1"><i class="fa fa-credit-card"></i> Master Card</p>[%/if%]
-							[%if [@name@] like 'Discover'%]<p class="mb-1"><i class="fa fa-credit-card"></i> Discover</p>[%/if%]
-							[%if [@name@] like 'Diners'%]<p class="mb-1"><i class="fa fa-credit-card"></i> Diners</p>[%/if%]
-							[%if [@name@] like 'Cheque'%]<p class="mb-1">Cheque</p>[%/if%]
-							[%if [@name@] like 'Money Order'%]<p class="mb-1">Money Order</p>[%/if%]
-							[%if [@name@] like 'Direct Deposit' OR [@name@] like 'Bank Deposit'%]<p class="mb-1">Direct Deposit</p>[%/if%]
-							[%if [@name@] like 'bpay'%]<p class="mb-1">BPAY</p>[%/if%]
-							[%if [@name@] like 'PayPal' OR [@name@] like 'paypal'%]<p class="mb-1"><i class="fa fa-credit-card"></i> Paypal</p>[%/if%]
-							[%if [@name@] like 'afterpay'%]<p class="mb-1"><i class="fa fa-credit-card"></i> Afterpay</p>[%/if%]
-							[%if [@name@] like 'Q Card' OR [@name@] like 'QCard'%]<p class="mb-1"><i class="fa fa-credit-card"></i> Q Card</p>[%/if%]
-							[%if [@name@] like 'Paymark Online Eftpos' OR [@name@] like 'Paymark'%]<p class="mb-1"><i class="fa fa-credit-card"></i> Paymark</p>[%/if%]
-							[%if [@name@] like 'zipMoney'%]<p class="mb-1"><i class="fa fa-credit-card"></i> zipMoney</p>[%/if%]
-							[%if [@name@] like 'zipPay'%]<p class="mb-1"><i class="fa fa-credit-card"></i> zipPay</p>[%/if%]
-							[%if [@name@] like 'Account'%]<p class="mb-1">[@config:company_name@] Account </p>[%/if%]
+							<p class="mb-1">
+								[%if [@charge_type@] eq 'web' OR [@charge_type@] eq 'cc'%]<i class="fa fa-credit-card"></i> [%/if%]
+								[%if [@charge_type@] eq 'acc'%][@config:company_name@] [%/if%]
+								[@name@]
+							</p>
 						[%/param%]
 						[%param *ifempty%]
 							<p class="mb-1">No Payment method has been selected</p>


### PR DESCRIPTION
The invoice page payment method section will only display a select amount of options because it uses a static if statement to figure out which payment method to display. 

This isn't scaleable for new options (e.g web payments) and also the name doesn't reflect what the merchant has placed in for the pay option (e.g they might have changed direct deposit to something more specific, this new name wouldn't have displayed in the current setup).