### PR TITLE
Added Meta for noindex, nofollow

### DIFF
--- a/src/templates/headers/includes/head.template.html
+++ b/src/templates/headers/includes/head.template.html
@@ -10,6 +10,9 @@
 <meta property="og:url" content="[@config:canonical_url@]"/>
 <meta property="og:description" content="[%url_info name:'meta_description'/%]"/>
 [%if [@config:GOOGLE_VERIFICATION@] %]<meta name="google-site-verification" content="[@config:GOOGLE_VERIFICATION@]">[%/if%]
+[%if [@config:current_page_type@] eq 'checkout' OR [@config:current_page_type@] eq 'customer'%]
+    <meta name="robots" content="noindex, nofollow">
+[%/if%]
 <title itemprop='name'>[%url_info name:'page_title'/%]</title>
 <link rel="canonical" href="[@config:canonical_url@]" itemprop="url"/>
 <link rel="shortcut icon" href="/assets/favicon_logo.png?[@config:neto_css_version@]"/>


### PR DESCRIPTION
This will add some more blocking ability on cart page and myacct page (deeper account pages are fine because blocked by password login.
Just helps line up with robots file more and with Google info - https://support.google.com/webmasters/answer/6062608?hl=en