### PR TITLE
CAT-1051 added async param to addToCartInit function

### DIFF
--- a/src/js/custom.js
+++ b/src/js/custom.js
@@ -18,7 +18,8 @@
 			$.addToCartInit({
 				'cart_id' :  'cartcontents',
 				'target_id': 'cartcontentsheader',
-				'image_rel': 'itmimg'
+				'image_rel': 'itmimg',
+				'async': true
 			});
 
 			$('.disp_ajax_templ').off();


### PR DESCRIPTION
Please note this param isn't in production yet so it will not work.

Change addToCartInit to allow async as a param so the initial ajax call doesn't block the thread.

This significantly increases performance and best practices in audits like lighthouse.