### PR TITLE
IE compatibility mode meta tag

### DIFF
--- a/src/templates/headers/includes/head.template.html
+++ b/src/templates/headers/includes/head.template.html
@@ -1,4 +1,5 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<meta http-equiv="x-ua-compatible" content="ie=edge">
 <meta name="keywords" content="[%url_info name:'meta_keywords'/%]"/>
 <meta name="description" content="[%url_info name:'meta_description'/%]"/>
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION
Internet Explorer supports the use of a document compatibility `<meta>` tag to specify what version of IE the page should be rendered as. Unless circumstances require otherwise, it's most useful to instruct IE to use the latest supported mode with edge mode.

For more information, [read this awesome Stack Overflow article](https://stackoverflow.com/questions/6771258/what-does-meta-http-equiv-x-ua-compatible-content-ie-edge-do).