### PR TITLE
Cart Disabled QTY Fix

### DIFF
--- a/src/templates/cart/shopping_cart.template.html
+++ b/src/templates/cart/shopping_cart.template.html
@@ -98,7 +98,7 @@
 							</td>
 							<td class="options-column">
 								<input name="line[@count@]" type="hidden" value="[@counter@]" />
-								<input id="qty[@count@]"  type="number" min="0" name="qty[@count@]" value="[@qty@]" class="form-control cart-qty" [%if [@aff_id@] eq 'free'%] disabled [%/if%] aria-label="[@model@] Quantity"/>
+								<input id="qty[@count@]"  type="number" min="0" name="qty[@count@]" value="[@qty@]" class="form-control cart-qty [%if [@aff_id@] eq 'free'%] readonly [%/if%]" [%if [@aff_id@] eq 'free'%] readonly [%/if%] aria-label="[@model@] Quantity"/>
 							</td>
 							<td class="text-right">
 								[%if [@qty@] > 1%]


### PR DESCRIPTION
Changed line 101 to be READONLY values rather than DISABLED. DISABLED form values do not submit; therefore if these trigger they are never submitted to checkout. Changed to READONLY to address this.