### PR TITLE
node_sass for development

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,8 @@ var { task, src, dest, watch, series, parallel } = require('gulp'),
 	autoprefixer = require('autoprefixer'),
 	cssnano = require('cssnano');
 
+sass.compiler = require('node-sass');
+
 // -------------------- Configure object --------------------
 var config = {};
 config.src = './src';

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,9 @@
 			"dev": true
 		},
 		"ajv": {
-			"version": "6.6.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
-			"integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+			"version": "6.10.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+			"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
@@ -608,7 +608,7 @@
 		},
 		"camelcase-keys": {
 			"version": "2.1.0",
-			"resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 			"dev": true,
 			"requires": {
@@ -806,9 +806,9 @@
 			"dev": true
 		},
 		"combined-stream": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
@@ -3499,9 +3499,9 @@
 			"integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
 		},
 		"js-base64": {
-			"version": "2.4.9",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.9.tgz",
-			"integrity": "sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
+			"integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==",
 			"dev": true
 		},
 		"js-yaml": {
@@ -3641,15 +3641,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.14",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-			"integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-			"dev": true
-		},
-		"lodash.assign": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
 			"dev": true
 		},
 		"lodash.clonedeep": {
@@ -3662,12 +3656,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
 			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-			"dev": true
-		},
-		"lodash.mergewith": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-			"integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
 			"dev": true
 		},
 		"lodash.uniq": {
@@ -3769,7 +3757,7 @@
 		},
 		"meow": {
 			"version": "3.7.0",
-			"resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"dev": true,
 			"requires": {
@@ -3807,18 +3795,18 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.37.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-			"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+			"version": "1.42.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+			"integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.21",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-			"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+			"version": "2.1.25",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+			"integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
 			"dev": true,
 			"requires": {
-				"mime-db": "~1.37.0"
+				"mime-db": "1.42.0"
 			}
 		},
 		"minimatch": {
@@ -3832,7 +3820,7 @@
 		},
 		"minimist": {
 			"version": "1.2.0",
-			"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 			"dev": true
 		},
@@ -3887,9 +3875,9 @@
 			"dev": true
 		},
 		"nan": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-			"integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
 			"dev": true
 		},
 		"nanomatch": {
@@ -3939,7 +3927,7 @@
 			"dependencies": {
 				"semver": {
 					"version": "5.3.0",
-					"resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
 					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
 					"dev": true
 				}
@@ -3955,9 +3943,9 @@
 			}
 		},
 		"node-sass": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
-			"integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.0.tgz",
+			"integrity": "sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==",
 			"dev": true,
 			"requires": {
 				"async-foreach": "^0.1.3",
@@ -3967,12 +3955,10 @@
 				"get-stdin": "^4.0.1",
 				"glob": "^7.0.3",
 				"in-publish": "^2.0.0",
-				"lodash.assign": "^4.2.0",
-				"lodash.clonedeep": "^4.3.2",
-				"lodash.mergewith": "^4.6.0",
+				"lodash": "^4.17.15",
 				"meow": "^3.7.0",
 				"mkdirp": "^0.5.1",
-				"nan": "^2.10.0",
+				"nan": "^2.13.2",
 				"node-gyp": "^3.8.0",
 				"npmlog": "^4.0.0",
 				"request": "^2.88.0",
@@ -3989,7 +3975,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -4256,7 +4242,7 @@
 		},
 		"os-homedir": {
 			"version": "1.0.2",
-			"resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 			"dev": true
 		},
@@ -4271,7 +4257,7 @@
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
-			"resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"dev": true
 		},
@@ -6322,9 +6308,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.1.29",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+			"integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
 			"dev": true
 		},
 		"pump": {
@@ -6620,12 +6606,12 @@
 			"dev": true
 		},
 		"rimraf": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "^7.1.3"
 			}
 		},
 		"safe-buffer": {
@@ -6679,7 +6665,7 @@
 			"dependencies": {
 				"source-map": {
 					"version": "0.4.4",
-					"resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"dev": true,
 					"requires": {
@@ -6957,9 +6943,9 @@
 			"dev": true
 		},
 		"sshpk": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-			"integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
 			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
@@ -7545,9 +7531,9 @@
 			}
 		},
 		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
 			"dev": true
 		},
 		"v8flags": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"gulp-plumber": "^1.2.1",
 		"gulp-postcss": "^8.0.0",
 		"gulp-sass": "^4.0.2",
+		"node-sass": "^4.13.0",
 		"ntheme": "^1.9.0",
 		"simple-github-release": "git+https://github.com/brandonsheppard/simple-github-release.git"
 	},


### PR DESCRIPTION
gulp-sass now recommend having a direct dependency of `node-sass`:

- https://www.npmjs.com/package/gulp-sass#install

Without this, it spits out a string of warnings and errors when installing the dependencies. And now it's more explicit with the compiler:

- https://www.npmjs.com/package/gulp-sass#basic-usage