### PR TITLE
Add maxlength 255 to the custom field textarea

### DIFF
--- a/src/templates/customer/wholesaleregister/template.html
+++ b/src/templates/customer/wholesaleregister/template.html
@@ -155,7 +155,7 @@
 						[%if [@required_field@]%]<span class="text-danger">*</span>[%/if%]
 					</label>
 					<div class="col-md-9">
-						<textarea name="[@field_id@]" class="form-control" cols="20" [%if [@required_field@]%]required[%/if%]>[%NOHTML%][@field_default@][%END NOHTML%]</textarea>
+						<textarea name="[@field_id@]" class="form-control" cols="20" maxlength="255" [%if [@required_field@]%]required[%/if%]>[%NOHTML%][@field_default@][%END NOHTML%]</textarea>
 					</div>
 				</div>
 			[%/param%]


### PR DESCRIPTION
When content from this text area gets imported into the control panel customer card, it cuts off at 255 characters. Adding `maxlength` will prevent customers from going over this limit.