### PR TITLE
Cart upsell make image responsive

### DIFF
--- a/src/templates/cart/upsell.template.html
+++ b/src/templates/cart/upsell.template.html
@@ -28,7 +28,7 @@
 								</div>
 								<div class="row">
 									<div class="col-12 col-sm-4">
-										<img src="[@thumb@]" align="left" alt="[@model@]" border="0">
+										<img src="[@thumb@]" class="img-fluid" alt="[@model@]" border="0">
 									</div>
 									<div class="options-form-container col-12 col-sm-8">
 										[%extra_options id:'[@SKU@]' currentextra:'[@currentextras@]'%]


### PR DESCRIPTION
The upsell image isn't responsive so it's overlapping the form fields:

![Screen Shot 2020-09-16 at 3 23 20 pm](https://user-images.githubusercontent.com/24999501/93295632-cffffc00-f830-11ea-9267-a356c562cbab.png)
