### PR TITLE
Child products that contain extra options issue

### DIFF
--- a/src/templates/products/includes/child_products.template.html
+++ b/src/templates/products/includes/child_products.template.html
@@ -114,9 +114,7 @@
 			[%PARAM *body%]
 							<tr>
 								<td>
-									[%if [@extra@] or [@has_child@] %]
-										<input type="text" value="" id="nov[@rndm@][@SKU@]" name="nov[@rndm@][@SKU@]" placeholder="Qty" class="form-control" disabled>
-									[%elseif [@available_preorder_quantity@] > 0 AND [@preorder@] AND [@config:WEBSTORE_USE_PREORDER_QUANTITY@]%]
+									[%if [@available_preorder_quantity@] > 0 AND [@preorder@] AND [@config:WEBSTORE_USE_PREORDER_QUANTITY@]%]
 										<input type="text" id="qty[@rndm@][@SKU@]" name="qty[@rndm@][@SKU@]" value="" placeholder="Qty" class="form-control">
 										<input type="hidden" id="sku[@rndm@][@SKU@]" name="sku[@rndm@][@SKU@]" value="[@SKU@]">
 										<input type="hidden" id="model[@rndm@][@SKU@]" name="model[@rndm@][@SKU@]" value="[@model@]">
@@ -146,9 +144,7 @@
 								</td>
 								<td>
 									<div class="child-price">[%format type:'currency'%][@price@][%END format%]</div>
-									[%if [@extra@] or [@has_child@] %]
-										<a href="[@URL@]" title="Buying Options" class="btn btn-primary">See Buying Options</a>
-									[%elseif [@available_preorder_quantity@] > 0 AND [@preorder@] AND [@config:WEBSTORE_USE_PREORDER_QUANTITY@]%]
+									[%if [@available_preorder_quantity@] > 0 AND [@preorder@] AND [@config:WEBSTORE_USE_PREORDER_QUANTITY@]%]
 										<span class="badge badge-warning">Pre-Order</span>
 									[%elseif [@store_quantity@] > 0 AND [@preorder@] AND ![@config:WEBSTORE_USE_PREORDER_QUANTITY@]%]
 										<span class="badge badge-warning">Pre-Order</span>


### PR DESCRIPTION
For child products that contain extra options, the current logic displays a "See buying Options" button (which does nothing) and disables the quantity field which prevents customers from purchasing the product. 

Example of issue: http://horsup.neto.com.au/dress?nview=country

![Screen Shot 2020-09-16 at 3 31 31 pm](https://user-images.githubusercontent.com/24999501/93296014-b4492580-f831-11ea-8886-07abb6a8e5cf.png)
