### PR TITLE
Remove non existent filter_category parameter

### DIFF
--- a/src/templates/cms/home.template.html
+++ b/src/templates/cms/home.template.html
@@ -44,7 +44,7 @@
 				</section>
 			[%/param%]
 			[%param *ifempty%]
-				[%random_products filter_category:'' template:'' limit:'8'%]
+				[%random_products category:'' template:'' limit:'8'%]
 					[%param *header%]
 						<hr aria-hidden="true"/>
 						<h2 class="sr-only">Featured products</h2>


### PR DESCRIPTION
Remove the non existent filter_category parameter from the [%random_products function and replace it with category - as per documentation on  https://developers.neto.com.au/documentation/neto-designer-documentation/b-se-tag-library/function-tags/list-content-and-products/random_products/

When you put a category_id in the filter_category parameter is doesn't work. It works however if the parameter is just "category"