### PR TITLE
Added Missing Check For 'Pending Dispatch' To Add badge-warning class

### DIFF
--- a/src/templates/customer/template.html
+++ b/src/templates/customer/template.html
@@ -178,7 +178,7 @@
 						<p class="mb-0">
 							<a href="[%url page:'account' type:'view_order' id:'[@order_id@]'/%]" aria-label="Order [@order_id@]">[@order_id@]</a>
 							<span class="badge float-right
-								[%if [@order_status@] eq 'On Hold' or [@order_status@] eq 'Backorder Approved' or [@order_status@] eq 'New Backorder'%]
+								[%if [@order_status@] eq 'On Hold' or [@order_status@] eq 'Backorder Approved' or [@order_status@] eq 'New Backorder' or [@order_status@] eq 'Pending Dispatch'%]
 										badge-warning
 									[%elseif [@order_status@] eq 'Pick' or [@order_status@] eq 'Pack'%]
 										badge-info


### PR DESCRIPTION
- Currently, if order status is 'Pending Dispatch', it is not adding 'badge-warning' class to the due to which order status 'Pending Dispatch' background colour remains white which is not legible.